### PR TITLE
add Coveralls GitHub Action to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,6 @@ jobs:
         with:
           name: coverage-report
           path: coverage/
+
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v2.3.6


### PR DESCRIPTION
This pull request includes a small change to the CI workflow configuration file. The change adds the Coveralls GitHub Action to the `jobs` section to integrate coverage reporting.

Changes to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR64-R66): Added the Coveralls GitHub Action (`coverallsapp/github-action@v2.3.6`) to enable coverage reporting.