### PR TITLE
Consolidate tool installation steps and adjust timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     env:
       RAILS_ENV: test
@@ -30,11 +31,10 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
 
-      - name: Install ImageMagick
-        run: sudo apt-get update && sudo apt-get install -y imagemagick
-
-      - name: Install SQLite3
-        run: sudo apt-get install -y sqlite3 libsqlite3-dev
+      - name: Install tools (ImageMagick, SQLite3, etc.)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick sqlite3 libsqlite3-dev
 
       - name: Install Google Chrome
         run: |
@@ -54,6 +54,7 @@ jobs:
 
       - name: Run RSpec tests
         run: bundle exec rspec
+        timeout-minutes: 5
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ develop ]
 
 jobs:
-  test:
+  rspec:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/ci.yml` to improve efficiency and maintainability. Key changes include introducing timeout settings for jobs and consolidating installation steps for tools.

### Workflow improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR12): Added a `timeout-minutes` setting of 10 minutes to the `test` job to prevent long-running processes from blocking the pipeline.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR57): Added a `timeout-minutes` setting of 5 minutes to the RSpec test step to ensure test runs are time-bound.

### Code simplification:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-R37): Consolidated the installation of ImageMagick and SQLite3 into a single step for improved readability and maintainability.…timeouts