### PR TITLE
メールテンプレートの I18n 対応漏れ修正

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.en.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.en.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'Confirm my account', user_confirmation_url(confirmation_token: @token, locale: I18n.locale) %></p>

--- a/app/views/devise/mailer/confirmation_instructions.ja.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.ja.html.erb
@@ -2,4 +2,4 @@
 
 <p>以下のリンクから、メールアドレスの確認ができます：</p>
 
-<p><%= link_to '確認する', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to '確認する', user_confirmation_url(confirmation_token: @token, locale: I18n.locale) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.en.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.en.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token, locale: I18n.locale) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/reset_password_instructions.ja.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.ja.html.erb
@@ -2,7 +2,7 @@
 
 <p>どなたかがパスワードの変更をリクエストしました。以下のリンクからパスワードを変更できます。</p>
 
-<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token, locale: I18n.locale) %></p>
 
 <p>この操作に心当たりがない場合は、このメールを無視してください。</p>
 <p>上記のリンクにアクセスして新しいパスワードを設定するまでは、パスワードは変更されません。</p>

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Devise Mailer', type: :mailer do
+  include ActionMailer::TestHelper
+
+  let(:user) { create(:user, :unconfirmed, email: 'test@example.com') }
+  let(:reset_token) { 'test_reset_token' }
+  let(:confirmation_token) { 'test_confirmation_token' }
+  let(:mailer_sender) { Devise.mailer_sender }
+
+  # ActionMailerの設定から値を取得
+  let(:mailer_url_options) { Rails.application.config.action_mailer.default_url_options }
+  let(:host) { mailer_url_options[:host] }
+  let(:port) { mailer_url_options[:port] }
+  let(:protocol) { mailer_url_options[:protocol] || 'http' }
+  let(:base_url) do
+    url = "#{protocol}://#{host}"
+    url += ":#{port}" if port.present? && port.to_s != '80' && port.to_s != '443'
+    url
+  end
+
+  describe 'confirmation instructions email' do
+    context 'in Japanese locale' do
+      it 'renders without errors and includes locale parameter in URL' do
+        I18n.with_locale(:ja) do
+          mail = nil
+
+          expect {
+            mail = Devise::Mailer.confirmation_instructions(user, confirmation_token)
+          }.not_to raise_error
+
+          expect(mail.subject).to eq(I18n.t('devise.mailer.confirmation_instructions.subject'))
+          expect(mail.to).to eq([user.email])
+          expect(mail.from).to eq([mailer_sender])
+
+          body = mail.body.to_s
+          expect(body).to include("確認") # メール種別の大まかな判別
+          expected_url = "#{base_url}/ja/users/confirmation?confirmation_token=#{confirmation_token}"
+          expect(body).to include(expected_url)
+        end
+      end
+
+      it 'can be delivered successfully' do
+        I18n.with_locale(:ja) do
+          mail = Devise::Mailer.confirmation_instructions(user, confirmation_token)
+
+          expect {
+            mail.deliver_now
+          }.not_to raise_error
+
+          expect(ActionMailer::Base.deliveries).not_to be_empty
+          delivered_mail = ActionMailer::Base.deliveries.last
+          expect(delivered_mail.to).to eq([user.email])
+          expect(delivered_mail.subject).to eq(I18n.t('devise.mailer.confirmation_instructions.subject'))
+          expect(delivered_mail.from).to eq([mailer_sender])
+        end
+      end
+    end
+
+    context 'in English locale' do
+      it 'renders without errors and includes locale parameter in URL' do
+        I18n.with_locale(:en) do
+          mail = nil
+
+          expect {
+            mail = Devise::Mailer.confirmation_instructions(user, confirmation_token)
+          }.not_to raise_error
+
+          expect(mail.subject).to eq(I18n.t('devise.mailer.confirmation_instructions.subject'))
+          expect(mail.to).to eq([user.email])
+          expect(mail.from).to eq([mailer_sender])
+
+          body = mail.body.to_s
+          expect(body).to include("confirm") # メール種別の大まかな判別
+          expected_url = "#{base_url}/en/users/confirmation?confirmation_token=#{confirmation_token}"
+          expect(body).to include(expected_url)
+        end
+      end
+
+      it 'can be delivered successfully' do
+        I18n.with_locale(:en) do
+          mail = Devise::Mailer.confirmation_instructions(user, confirmation_token)
+
+          expect {
+            mail.deliver_now
+          }.not_to raise_error
+
+          expect(ActionMailer::Base.deliveries).not_to be_empty
+          delivered_mail = ActionMailer::Base.deliveries.last
+          expect(delivered_mail.to).to eq([user.email])
+          expect(delivered_mail.subject).to eq(I18n.t('devise.mailer.confirmation_instructions.subject'))
+          expect(delivered_mail.from).to eq([mailer_sender])
+        end
+      end
+    end
+  end
+
+  describe 'reset password instructions email' do
+    context 'in Japanese locale' do
+      it 'renders without errors and includes locale parameter in URL' do
+        I18n.with_locale(:ja) do
+          mail = nil
+
+          expect {
+            mail = Devise::Mailer.reset_password_instructions(user, reset_token)
+          }.not_to raise_error
+
+          expect(mail.subject).to eq(I18n.t('devise.mailer.reset_password_instructions.subject'))
+          expect(mail.to).to eq([user.email])
+          expect(mail.from).to eq([mailer_sender])
+
+          body = mail.body.to_s
+          expect(body).to include("パスワード") # メール種別の大まかな判別
+          expected_url = "#{base_url}/ja/users/password/edit?reset_password_token=#{reset_token}"
+          expect(body).to include(expected_url)
+        end
+      end
+
+      it 'can be delivered successfully' do
+        I18n.with_locale(:ja) do
+          mail = Devise::Mailer.reset_password_instructions(user, reset_token)
+
+          expect {
+            mail.deliver_now
+          }.not_to raise_error
+
+          expect(ActionMailer::Base.deliveries).not_to be_empty
+          delivered_mail = ActionMailer::Base.deliveries.last
+          expect(delivered_mail.to).to eq([user.email])
+          expect(delivered_mail.subject).to eq(I18n.t('devise.mailer.reset_password_instructions.subject'))
+          expect(delivered_mail.from).to eq([mailer_sender])
+        end
+      end
+    end
+
+    context 'in English locale' do
+      it 'renders without errors and includes locale parameter in URL' do
+        I18n.with_locale(:en) do
+          mail = nil
+
+          expect {
+            mail = Devise::Mailer.reset_password_instructions(user, reset_token)
+          }.not_to raise_error
+
+          expect(mail.subject).to eq(I18n.t('devise.mailer.reset_password_instructions.subject'))
+          expect(mail.to).to eq([user.email])
+          expect(mail.from).to eq([mailer_sender])
+
+          body = mail.body.to_s
+          expect(body).to include("password") # メール種別の大まかな判別
+          expected_url = "#{base_url}/en/users/password/edit?reset_password_token=#{reset_token}"
+          expect(body).to include(expected_url)
+        end
+      end
+
+      it 'can be delivered successfully' do
+        I18n.with_locale(:en) do
+          mail = Devise::Mailer.reset_password_instructions(user, reset_token)
+
+          expect {
+            mail.deliver_now
+          }.not_to raise_error
+
+          expect(ActionMailer::Base.deliveries).not_to be_empty
+          delivered_mail = ActionMailer::Base.deliveries.last
+          expect(delivered_mail.to).to eq([user.email])
+          expect(delivered_mail.subject).to eq(I18n.t('devise.mailer.reset_password_instructions.subject'))
+          expect(delivered_mail.from).to eq([mailer_sender])
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/devise_mailer_integration_spec.rb
+++ b/spec/requests/devise_mailer_integration_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Devise Mailer Integration', type: :request do
+  include ActionMailer::TestHelper
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe 'user registration flow' do
+    it 'sends confirmation email without errors and includes locale parameter' do
+      user_params = {
+        email: 'newuser@example.com',
+        username: 'newuser123',
+        password: 'password123',
+        password_confirmation: 'password123'
+      }
+
+      perform_enqueued_jobs do
+        expect {
+          post user_registration_path, params: { user: user_params }
+        }.not_to raise_error
+      end
+
+      expect(response).to have_http_status(:see_other) # redirects to sign in page
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to include('newuser@example.com')
+      expect(mail.subject).to match(/確認|Confirm/i)
+
+      # メール本文にlocaleパラメータが含まれていることを確認
+      body = mail.body.to_s
+      expect(body).to match(/\/(en|ja)\/users\/confirmation/)
+
+      # 実際のURLが正しい形式であることを確認
+      mailer_options = Rails.application.config.action_mailer.default_url_options
+      expected_host = mailer_options[:host]
+      expected_protocol = mailer_options[:protocol] || 'http'
+      expect(body).to include("#{expected_protocol}://#{expected_host}")
+    end
+
+    it 'handles different locales correctly' do
+      user_params = {
+        email: 'jauser@example.com',
+        username: 'jauser123',
+        password: 'password123',
+        password_confirmation: 'password123'
+      }
+
+      perform_enqueued_jobs do
+        expect {
+          post user_registration_path(locale: :ja), params: { user: user_params }
+        }.not_to raise_error
+      end
+
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      mail = ActionMailer::Base.deliveries.last
+      body = mail.body.to_s
+      expect(body).to include('/ja/users/confirmation')
+    end
+  end
+
+  describe 'password reset flow' do
+    let(:existing_user) { create(:user, :confirmed) }
+
+    it 'sends password reset email without errors and includes locale parameter' do
+      perform_enqueued_jobs do
+        expect {
+          post user_password_path, params: { user: { email: existing_user.email } }
+        }.not_to raise_error
+      end
+
+      expect(response).to have_http_status(:see_other) # redirects back
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to include(existing_user.email)
+      expect(mail.subject).to match(/パスワード|Reset password|password/i)
+
+      # メール本文にlocaleパラメータが含まれていることを確認
+      body = mail.body.to_s
+      expect(body).to match(/\/(en|ja)\/users\/password\/edit/)
+
+      # 実際のURLが正しい形式であることを確認
+      mailer_options = Rails.application.config.action_mailer.default_url_options
+      expected_host = mailer_options[:host]
+      expected_protocol = mailer_options[:protocol] || 'http'
+      expect(body).to include("#{expected_protocol}://#{expected_host}")
+    end
+
+    it 'handles different locales correctly for password reset' do
+      perform_enqueued_jobs do
+        expect {
+          post user_password_path(locale: :ja), params: { user: { email: existing_user.email } }
+        }.not_to raise_error
+      end
+
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      mail = ActionMailer::Base.deliveries.last
+      body = mail.body.to_s
+      expect(body).to include('/ja/users/password/edit')
+    end
+  end
+end


### PR DESCRIPTION
メールテンプレート内の URL ヘルパー呼び出しの箇所が I18n 対応時に更新できておらず、ルートが存在しない例外になり、ユーザ登録ができない状態であった。

メモ： rspec は Claude のコードはちょっとヘンテコであったので GPT に依頼した。いったん完成したコードを見直させ、見直されたコードをさらに別のモデルで見直した。