### PR TITLE
使用していない Turbo Frame を取り除く

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,3 @@
-<turbo-frame id="devise">
 <div class="container p-4">
   <%= content_tag :h2, t('devise.registrations.account_settings'), class: 'text-2xl font-bold mb-4', **data_with_testid('account-settings-title') %>
 
@@ -141,11 +140,9 @@
         method: :delete,
         class: "text-white bg-red-600 hover:bg-red-700 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center",
         **data_with_testid('account-cancel',
-          turbo_frame: '_top', # 重要! frame 指定のままだと余分なリダイレクトが発生し、その場合 flash も消えてしまいます
           turbo_confirm: t('devise.registrations.cancel_confirm'),
         ),
       )
     %>
   </div>
 </div>
-</turbo-frame>

--- a/app/views/two_factor_settings/edit.html.erb
+++ b/app/views/two_factor_settings/edit.html.erb
@@ -1,31 +1,29 @@
-<turbo-frame id="devise">
-  <div class="container p-4">
+<div class="container p-4">
 
-    <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-4', **data_with_testid('two-factor-enabled-message') %>
+  <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-4', **data_with_testid('two-factor-enabled-message') %>
 
-    <%= render 'shared/flash' %>
+  <%= render 'shared/flash' %>
 
-    <p class="text-sm text-gray-500 mb-4">
-      <%= t('devise.sessions.two_factor_settings.enabled') %>
-    </p>
+  <p class="text-sm text-gray-500 mb-4">
+    <%= t('devise.sessions.two_factor_settings.enabled') %>
+  </p>
 
-    <div class="space-y-6">
-      <!-- Backup Codes Card -->
-      <div class="bg-white border border-gray-200 rounded-lg shadow-sm">
-        <div class="px-4 py-2 border-b border-gray-200">
-          <%= content_tag :h3, t('devise.sessions.two_factor_settings.backup_codes_title'), class: 'text-lg font-semibold text-gray-900', **data_with_testid('backup-codes-title') %>
-          <p class="text-sm text-gray-500">
-            <%= t('devise.sessions.two_factor_settings.backup_codes_instruction') %>
-          </p>
-        </div>
-        <div class="p-4 text-gray-700">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
-            <% @backup_codes.each do |code| %>
-              <%= content_tag :div, code, class: 'font-mono font-bold text-gray-900', **data_with_testid('backup-code') %>
-            <% end %>
-          </div>
+  <div class="space-y-6">
+    <!-- Backup Codes Card -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm">
+      <div class="px-4 py-2 border-b border-gray-200">
+        <%= content_tag :h3, t('devise.sessions.two_factor_settings.backup_codes_title'), class: 'text-lg font-semibold text-gray-900', **data_with_testid('backup-codes-title') %>
+        <p class="text-sm text-gray-500">
+          <%= t('devise.sessions.two_factor_settings.backup_codes_instruction') %>
+        </p>
+      </div>
+      <div class="p-4 text-gray-700">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+          <% @backup_codes.each do |code| %>
+            <%= content_tag :div, code, class: 'font-mono font-bold text-gray-900', **data_with_testid('backup-code') %>
+          <% end %>
         </div>
       </div>
     </div>
   </div>
-</turbo-frame>
+</div>

--- a/app/views/two_factor_settings/new.html.erb
+++ b/app/views/two_factor_settings/new.html.erb
@@ -1,4 +1,3 @@
-<turbo-frame id="devise">
 <div class="container p-4">
   <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-6', **data_with_testid('two-factor-enabled-message') %>
 
@@ -59,4 +58,3 @@
     </li>
   </ol>
 </div>
-</turbo-frame>

--- a/app/views/users/_frame_layout.html.erb
+++ b/app/views/users/_frame_layout.html.erb
@@ -1,11 +1,9 @@
-<turbo-frame id="devise">
-  <div class="container p-4">
-    <h2 class="text-2xl font-bold mb-4"><%= title %></h2>
+<div class="container p-4">
+  <h2 class="text-2xl font-bold mb-4"><%= title %></h2>
 
-    <%= render 'shared/flash' %>
+  <%= render 'shared/flash' %>
 
-    <div>
-      <%= yield %>
-    </div>
+  <div>
+    <%= yield %>
   </div>
-</turbo-frame>
+</div>


### PR DESCRIPTION
ユーザーの概念の実装時は、ユーザーメニュー画面は Turbo Frame を用いていましたが、ロケールの実装の都合で現段階ではフレームは使用しないように見直しました。フレームを指定するリンクはこれまでの改修で取り除いていましたが、ターゲットとしてのフレーム要素が残っていたので、それを片付けます。

ちなみに：フレームの実装時は、画面右上の言語スイッチのボタン（リンク）がありますが、ユーザーメニューでフレームを切り替えてもこの部分（リンク先 URL ）に変更が及ばない状況でした。／ユーザーが言語スイッチをクリックしたときは現在表示されている画面のままで言語だけが変わるのを期待しますが、元から存在する言語スイッチが保持しているリンク先の画面になってしまいます。（つまり言語が変わりながらも、別の画面になってしまう）／これを解消するためには言語スイッチも含めてフレームを更新するか、フレームを更新した時に Turbo Stream や JavaScript でリンク先も変えなければならず、それではコードも複雑になり、またフレームが活きる場面でも無いことから、フレームでのページ切り替えをやめるという選択に落ち着きました。

MEMO: 差分はほとんどインデントなので "-w" オプションをつけると見やすくなります。
