### PR TITLE
ApplicationController.renderer で render するテンプレート内で URL ヘルパーを使えるようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,11 +49,4 @@ module Annabelle
     # My experimental feature
     config.x.auto_login = config_for(Rails.root.join('config/x/auto_login.yml'))
   end
-
-  # Set default_url_options For Entire Application
-  # https://github.com/jbranchaud/til/blob/master/rails/set-default-url-options-for-entire-application.md
-  Rails.application.default_url_options = {
-    host: ENV['ANNABELLE_HOST'].presence || 'localhost',
-    port: ENV['ANNABELLE_PORT'].presence,
-  }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,16 @@ module Annabelle
 
     # My experimental feature
     config.x.auto_login = config_for(Rails.root.join('config/x/auto_login.yml'))
+
+    # Active Job の中でテンプレートを render する際に URL ヘルパーが使えるようにします。
+    # action_mailer 用の設定を複製し、両者で同じ URL になるようにしています。
+    #
+    # Job における default_url_options について（このやり方は期待通り働かず）：
+    # https://github.com/rails/rails/issues/29992#issuecomment-318819265
+    # その他参考：
+    # https://github.com/rails/rails/issues/39566
+    config.after_initialize do
+      Rails.application.routes.default_url_options = Rails.application.config.action_mailer.default_url_options.dup
+    end
   end
 end


### PR DESCRIPTION
少なくとも action_mailer の default_url の値と同期している必要があるものと判断し、 after_initialize を利用してみることにします。

コードのコメントに記していますが、 Rails のこの件に関する動向に、やや注意が必要かもしれません。デフォルトで全体的に使える何かが提供されると嬉しいのですが、さて。
