### PR TITLE
二要素認証の画面がユーザー・メニューを伴わない問題を修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def in_configuration_layout?
+    user_signed_in? && %w[registrations users two_factor_settings].include?(controller_name)
+  end
 end

--- a/app/views/layouts/_configuration_menu.html.erb
+++ b/app/views/layouts/_configuration_menu.html.erb
@@ -19,12 +19,15 @@
     </button>
   </div>
 
-  <div
-    data-drawer-target="drawer"
-    class="border border-gray-300 shadow-sm sm:border-0 sm:shadow-none
-     absolute sm:relative transform -translate-x-full sm:translate-x-0 sm:block transition-transform duration-300 ease-in-out p-4 bg-white w-64"
-    data-action="click->drawer#closeOnClick"
-  >
+  <%=
+    content_tag(:div,
+      class: "border border-gray-300 shadow-sm sm:border-0 sm:shadow-none absolute sm:relative transform -translate-x-full sm:translate-x-0 sm:block transition-transform duration-300 ease-in-out p-4 bg-white w-64",
+      **data_with_testid("configuration-menu", {
+        drawer_target: "drawer",
+        action: "click->drawer#closeOnClick",
+      }),
+    ) do
+  %>
     <ul class="space-y-4" role="navigation">
       <li>
         <%= link_to t('layouts.configuration_menu.dashboard'), dashboard_path, class: "block text-lg text-gray-700 hover:text-blue-500" %>
@@ -43,5 +46,5 @@
     <hr class="my-8">
 
     <%= link_to t('layouts.configuration_menu.sign_out'), destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: "block text-lg text-gray-700 hover:text-blue-500" %>
-  </div>
+  <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,6 @@
 <%
-  # ログインしている（いない）ユーザの情報を View で扱うためのプレゼンター。
+  # ユーザの情報を View で扱うためのプレゼンター。
   current_user_presenter = CurrentUserPresenter.new(self, current_user)
-
-  # 設定画面用のレイアウトにするか否か
-  in_configuration = (controller_name == 'registrations' || controller_name == 'users') && user_signed_in?
 %>
 <!DOCTYPE html>
 <html>
@@ -39,7 +36,7 @@
       </div>
     </header>
 
-    <% if in_configuration %>
+    <% if in_configuration_layout? %>
       <div class="flex flex-1">
         <nav class="px-2">
           <%= render 'layouts/configuration_menu' %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#in_configuration_layout?' do
+    before do
+      allow(helper).to receive(:user_signed_in?).and_return(true)
+    end
+
+    it 'returns true for registrations controller' do
+      allow(helper).to receive(:controller_name).and_return('registrations')
+      expect(helper.in_configuration_layout?).to be true
+    end
+
+    it 'returns true for users controller' do
+      allow(helper).to receive(:controller_name).and_return('users')
+      expect(helper.in_configuration_layout?).to be true
+    end
+
+    it 'returns true for two_factor_settings controller' do
+      allow(helper).to receive(:controller_name).and_return('two_factor_settings')
+      expect(helper.in_configuration_layout?).to be true
+    end
+
+    it 'returns false for other controllers' do
+      allow(helper).to receive(:controller_name).and_return('messages')
+      expect(helper.in_configuration_layout?).to be false
+    end
+
+    it 'returns false if user is not signed in' do
+      allow(helper).to receive(:user_signed_in?).and_return(false)
+      allow(helper).to receive(:controller_name).and_return('users')
+      expect(helper.in_configuration_layout?).to be false
+    end
+  end
+end

--- a/spec/system/layouts_spec.rb
+++ b/spec/system/layouts_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Configuration menu layout', type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  def login_as(user)
+    visit new_user_session_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+
+  before do
+    login_as(user)
+  end
+
+  it 'shows configuration menu for registrations controller' do
+    visit edit_user_registration_path
+    expect(page).to have_selector('[data-testid="configuration-menu"]')
+  end
+
+  it 'shows configuration menu for users controller (dashboard)' do
+    visit dashboard_path
+    expect(page).to have_selector('[data-testid="configuration-menu"]')
+  end
+
+  it 'shows configuration menu for two_factor_settings controller' do
+    visit new_two_factor_settings_path
+    expect(page).to have_selector('[data-testid="configuration-menu"]')
+  end
+
+  it 'does not show configuration menu for messages controller' do
+    visit messages_path
+    expect(page).not_to have_selector('[data-testid="configuration-menu"]')
+  end
+end


### PR DESCRIPTION
#6 で Turbo Frame を取り除いたことによる影響で、 UsersController コントローラとは異なるコントローラで実装していた TwoFactorSettingsController の View が、ユーザー・メニュー（画面左のメニュー）の表示がない状態で画面遷移をするようになっていました。

ユーザー・メニューからのリンクは、選択するべきレイアウト・ファイルが異なるので、その判定を更新し、UsersController コントローラと同じように TwoFactorSettingsController でもユーザー・メニューを持ったレイアウトが選択されるように修正しました。

この際に rspec も追加し、どちらのレイアウトが選択されるかを確認するようにしています。
