### PR TITLE
JavaScript 警告 "Input elements should have autocomplete attributes" の対応

### DIFF
--- a/app/views/two_factor_settings/new.html.erb
+++ b/app/views/two_factor_settings/new.html.erb
@@ -46,7 +46,7 @@
 
             <div class="mb-4">
               <%= form.label :password, t('devise.sessions.two_factor_settings.current_password_label'), class: "block font-medium text-gray-700" %>
-              <%= form.password_field :password, class: "mt-1 block w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500", **data_with_testid('current-password-input') %>
+              <%= form.password_field :password, autocomplete: "current-password", class: "mt-1 block w-full p-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500", **data_with_testid('current-password-input') %>
             </div>
 
             <div>


### PR DESCRIPTION
#12 の対応です。警告のでていたフォームの \<input\> の password フィールドに autocomplete 属性を足します。

GPT-4.1 さんに app/views にある その他の erb を検索してもらいましたが、他に同様の箇所はないとのことです。