### PR TITLE
新規メッセージの赤いハイライトを既読時に取り除く

### DIFF
--- a/app/javascript/controllers/new_message_highlighter_controller.js
+++ b/app/javascript/controllers/new_message_highlighter_controller.js
@@ -1,0 +1,24 @@
+// This Stimulus controller removes the highlight from a new message when the user hovers or focuses it.
+// ユーザーが新着メッセージにマウスを乗せるかフォーカスすると、ハイライトを解除するStimulusコントローラです。
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.boundHandleUserActivity = this.handleUserActivity.bind(this)
+    this.element.addEventListener('mouseenter', this.boundHandleUserActivity)
+    this.element.addEventListener('focusin', this.boundHandleUserActivity)
+  }
+
+  disconnect() {
+    this.element.removeEventListener('mouseenter', this.boundHandleUserActivity)
+    this.element.removeEventListener('focusin', this.boundHandleUserActivity)
+  }
+
+  handleUserActivity() {
+    if (this.element.getAttribute('data-new-message') === 'true') {
+      this.element.removeAttribute('data-new-message')
+      this.element.removeEventListener('mouseenter', this.boundHandleUserActivity)
+      this.element.removeEventListener('focusin', this.boundHandleUserActivity)
+    }
+  }
+}

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -2,7 +2,7 @@
   class="mb-2 w-full min-w-0 p-4 bg-white rounded-lg shadow-xs overflow-auto scrollbar-gutter-stable"
   data-message-id="<%= message.id %>"
   data-owner-id="<%= message.user.id %>"
-  data-controller="message-ownership"
+  data-controller="message-ownership new-message-highlighter"
   <%= 'data-new-message="true"'.html_safe if defined?(as_new) && !!as_new %><%# see also tailwind definition %>
 >
   <div class="text-gray-400 text-xs pb-2">


### PR DESCRIPTION
#14 の対応で、新規メッセージの背景色が赤のまま（リロードするまで）戻らない点について改良します。

当初は背景色を、赤 --> 白（地の色）へ徐々に変化していくようにするイメージを持っていましたが、実装が複雑化することで再考し、現在の実装のようにフォーカスが入ったらすぐに白に戻るUIでも良さそうなので、シンプルなこともあり、その案を採用します。
