### PR TITLE
LCOV形式のカバレッジレポート出力（Coveralls向け）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,6 @@ jobs:
 
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage/lcov.info

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers", "~> 6.0"
   gem "simplecov", require: false
+  gem "simplecov-lcov", require: false
 end
 
 gem "solid_cable", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,6 +372,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
@@ -462,6 +463,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 6.0)
   simplecov
+  simplecov-lcov
   solid_cable (~> 3.0)
   sqlite3 (>= 2.1)
   stimulus-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,18 @@
 # (or spec_helper.rb, rails_helper, cucumber env.rb,
 # or whatever your preferred test framework uses):
 require 'simplecov'
+require 'simplecov-lcov'
+SimpleCov::Formatter::LcovFormatter.config do |c|
+  c.output_directory = 'coverage'
+  c.lcov_file_name = 'lcov.info'
+  c.report_with_single_file = true
+end
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::LcovFormatter,
+])
 SimpleCov.start 'rails'
+
 
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
Coveralls に送信するカバレッジのレポートは LCOV形式 というフォーマットを要するとのことで、この形式で出力し、 Coveralls へ送信するように GitHub Actions のステップも修正します。

従来の HTML 形式も見慣れているので出力しておこうと思います。

以下は Copilot による、この PR のサマリーです：

This pull request introduces changes to integrate LCOV coverage reporting into the CI pipeline and the test suite configuration. The most important updates include adding the `simplecov-lcov` gem, configuring LCOV formatting in the test suite, and updating the CI workflow to include LCOV coverage data.

### CI Pipeline Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR68-R70): Updated the Coveralls GitHub Action configuration to include LCOV coverage data by specifying the `github-token` and `path-to-lcov` parameters.

### Test Suite Configuration:
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR75): Added the `simplecov-lcov` gem to the test group for LCOV formatting support.
* [`spec/rails_helper.rb`](diffhunk://#diff-053aa3ea46cb7c6a649e0d0fc592ce729b66e1d44be475516fd58857ba695862R7-R19): Configured `simplecov-lcov` to generate LCOV reports in the `coverage` directory, set up a multi-formatter combining HTML and LCOV formats, and ensured LCOV reporting is integrated when SimpleCov starts.