### PR TITLE
メッセージを削除する際の confirm メッセージ修正

### DIFF
--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -11,7 +11,7 @@
         class: 'hidden',
         **data_with_testid("delete-message-#{message.id}",{
           turbo_method: :delete,
-          turbo_confirm: 'Sure?',
+          turbo_confirm: t('messages.delete_confirm'),
           message_ownership_target: 'owner',
         })
       )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,7 @@ en:
       sign_out: "Sign out"
       two_factor_authentication: "Two Factor Authentication"
   messages:
+    delete_confirm: "Are you sure you want to delete this message?"
     email_confirmation_required: "You need to confirm your email address before posting."
     errors:
       generic: "An error occurred: %{error_message}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -112,6 +112,7 @@ ja:
       sign_out: "ログアウト"
       two_factor_authentication: "二要素認証"
   messages:
+    delete_confirm: "このメッセージを削除してもよろしいですか？"
     email_confirmation_required: "投稿するにはメールアドレスの確認が必要です。"
     errors:
       generic: "エラーが発生しました: %{error_message}"


### PR DESCRIPTION
投稿メッセージの削除の際の確認メッセージが I18n 対応になっていなかったので、対応させます。
