### PR TITLE
LocaleController のリダイレクト先の値の、チェックを強化

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
       invalid_type: "must be a String or Symbol"
       invalid_value: "is not a valid locale"
       unsupported_locale: "Unsupported locale"
+      invalid_redirect_path: "Invalid redirect path specified"
     messages:
       accepted: "must be accepted"
       blank: "can't be blank"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -77,6 +77,7 @@ ja:
       invalid_type: "は文字列またはシンボルである必要があります"
       invalid_value: "は有効なロケールではありません"
       unsupported_locale: "サポートされていない言語です"
+      invalid_redirect_path: "不正なリダイレクト先が指定されました"
     messages:
       accepted: "を受諾してください"
       blank: "を入力してください"


### PR DESCRIPTION
LocaleController におけるリダイレクトの処理で、リダイレクト先の指定がパラメータ "redirect_to" が使われますが、その値はクライアント側から（ユーザが自由に変更できる値）からの入力になるので、セキュリティ的には大丈夫かどうか Claude Sonnet 4 に評価してもらい、改善案を実装してもらったものになります。

以下は Copilot によるこの PR のサマリーです：

This pull request introduces robust validations for redirect paths in the locale management system, improving security and user experience. The changes include the addition of custom exceptions, enhanced path validation logic, and comprehensive test coverage for edge cases such as malformed paths, control characters, and URL encoding attacks.

### Security Enhancements

* **Custom Exception for Path Validation**: Introduced a new `LocalePathValidationError` exception in `LocaleHelper` to handle invalid path formats explicitly.
* **Enhanced Path Validation**: Updated `validate_path!` in `LocaleHelper` to include checks for path length, URL encoding attacks, and non-string inputs. Paths with control characters, traversal sequences (`..`), or double slashes are now explicitly rejected.

### User Experience Improvements

* **Graceful Fallback for Invalid Redirects**: Modified the `update` method in `LocaleController` to log warnings and redirect users to the root path with an alert message when invalid paths are detected.
* **Localized Error Messages**: Added new translations for invalid redirect path errors in both English (`config/locales/en.yml`) and Japanese (`config/locales/ja.yml`). [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R80) [[2]](diffhunk://#diff-b85e8d609d1ca8ea9aef96cf26c7011d39b5dd2e7de34dd4c52d931979917508R80)

### Comprehensive Test Coverage

* **Unit Tests for Path Validation**: Expanded `locale_helper_spec` to cover edge cases such as overly long paths, URL encoding attacks, and non-string inputs. Added tests for Unicode and special character handling. [[1]](diffhunk://#diff-4cdf835f4a966d70ef42dfd88efd9fbf8230d2778fcc61ee39b92fe012fb33a3L51-R87) [[2]](diffhunk://#diff-4cdf835f4a966d70ef42dfd88efd9fbf8230d2778fcc61ee39b92fe012fb33a3R245-R257)
* **Integration Tests for LocaleController**: Added request specs to ensure invalid `redirect_to` parameters are handled gracefully, including logging and user alerts.