### PR TITLE
二要素認証の画面フローの見直し（ flash が表示されない問題の修正）

### DIFF
--- a/app/controllers/two_factor_settings_controller.rb
+++ b/app/controllers/two_factor_settings_controller.rb
@@ -14,8 +14,8 @@ class TwoFactorSettingsController < ApplicationController
   # two_factor_settings POST /two_factor_settings(.:format)
   def create
     unless current_user.valid_password?(params_enabling_2fa[:password])
-      flash.now[:alert] = I18n.t('two_factor_settings.incorrect_password')
-      return render :new
+      flash[:alert] = I18n.t('two_factor_settings.incorrect_password')
+      return redirect_to new_two_factor_settings_path
     end
 
     if current_user.validate_and_consume_otp!(params_enabling_2fa[:code])
@@ -24,8 +24,8 @@ class TwoFactorSettingsController < ApplicationController
       flash[:notice] = I18n.t('two_factor_settings.enabled')
       redirect_to edit_two_factor_settings_path
     else
-      flash.now[:alert] = I18n.t('two_factor_settings.incorrect_code')
-      render :new
+      flash[:alert] = I18n.t('two_factor_settings.incorrect_code')
+      redirect_to new_two_factor_settings_path
     end
   end
 

--- a/app/views/two_factor_settings/edit.html.erb
+++ b/app/views/two_factor_settings/edit.html.erb
@@ -1,6 +1,5 @@
-<turbo-frame id="tfa">
+<turbo-frame id="tfa-settings">
 <div class="container p-4">
-
   <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-4', **data_with_testid('two-factor-enabled-message') %>
 
   <%= render 'shared/flash' %>

--- a/app/views/two_factor_settings/edit.html.erb
+++ b/app/views/two_factor_settings/edit.html.erb
@@ -1,3 +1,4 @@
+<turbo-frame id="tfa">
 <div class="container p-4">
 
   <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-4', **data_with_testid('two-factor-enabled-message') %>
@@ -27,3 +28,4 @@
     </div>
   </div>
 </div>
+</turbo-frame>

--- a/app/views/two_factor_settings/new.html.erb
+++ b/app/views/two_factor_settings/new.html.erb
@@ -1,3 +1,4 @@
+<turbo-frame id="tfa">
 <div class="container p-4">
   <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-6', **data_with_testid('two-factor-enabled-message') %>
 
@@ -30,7 +31,7 @@
 
           <%= render 'shared/flash' %>
 
-          <%= form_with scope: :two_fa, url: two_factor_settings_path, method: :post, local: true, data: { turbo: false } do |form| %>
+          <%= form_with scope: :two_fa, url: two_factor_settings_path, method: :post, data: { turbo_action: :advance } do |form| %>
             <div class="mb-4">
               <%= form.label :code, t('devise.sessions.two_factor_settings.otp_code_label'), class: "block font-medium text-gray-700" %>
               <%= form.text_field(:code,
@@ -58,3 +59,4 @@
     </li>
   </ol>
 </div>
+</turbo-frame>

--- a/app/views/two_factor_settings/new.html.erb
+++ b/app/views/two_factor_settings/new.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="tfa">
+<turbo-frame id="tfa-settings">
 <div class="container p-4">
   <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-6', **data_with_testid('two-factor-enabled-message') %>
 

--- a/app/views/two_factor_settings/new.html.erb
+++ b/app/views/two_factor_settings/new.html.erb
@@ -30,7 +30,7 @@
 
           <%= render 'shared/flash' %>
 
-          <%= form_with scope: :two_fa, url: two_factor_settings_path, method: :post, local: true do |form| %>
+          <%= form_with scope: :two_fa, url: two_factor_settings_path, method: :post, local: true, data: { turbo: false } do |form| %>
             <div class="mb-4">
               <%= form.label :code, t('devise.sessions.two_factor_settings.otp_code_label'), class: "block font-medium text-gray-700" %>
               <%= form.text_field(:code,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
       comment_label: "Comment"
       post: "Post"
   two_factor_settings:
+    already_enabled: "Two factor authentication is already enabled."
     backup_codes_already_seen: "You have already seen your backup codes."
     could_not_disable: "Could not disable two factor authentication."
     disable: "Disable Two Factor Authentication"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -122,6 +122,7 @@ ja:
       comment_label: "コメント"
       post: "投稿"
   two_factor_settings:
+    already_enabled: "二要素認証は既に有効になっています。"
     backup_codes_already_seen: "バックアップコードは既に表示済みです。"
     could_not_disable: "二要素認証を無効化できませんでした。"
     disable: "二要素認証を無効にする"

--- a/spec/requests/two_factor_settings_spec.rb
+++ b/spec/requests/two_factor_settings_spec.rb
@@ -102,7 +102,8 @@ RSpec.describe TwoFactorSettingsController, type: :request do
     context 'when password is incorrect' do
       it 'renders new with alert' do
         post two_factor_settings_path, params: { two_fa: { code: '123456', password: 'wrong' } }
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:found)
+        follow_redirect!
         expect(response.body).to include(I18n.t('two_factor_settings.incorrect_password'))
       end
     end
@@ -132,7 +133,8 @@ RSpec.describe TwoFactorSettingsController, type: :request do
 
         it 'renders new with alert' do
           post two_factor_settings_path, params: valid_params
-          expect(response).to have_http_status(:ok)
+          expect(response).to have_http_status(:found)
+          follow_redirect!
           expect(response.body).to include(I18n.t('two_factor_settings.incorrect_code'))
         end
       end

--- a/spec/system/two_factor_settings_spec.rb
+++ b/spec/system/two_factor_settings_spec.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'TwoFactorSettings', type: :system do
+  let(:password) { 'password123' }
+  let!(:user) { create(:user, password: password, password_confirmation: password, confirmed_at: Time.current) }
+
+  before { Capybara.reset_sessions! }
+
+  describe 'GET /two_factor_settings/new' do
+    context 'when user is not signed in' do
+      it 'redirects to sign in page' do
+        visit new_two_factor_settings_path
+        expect(page).to have_current_path(new_user_session_path)
+        expect(page).to have_content('Sign in')
+      end
+    end
+
+    context 'when user is signed in' do
+      before do
+        visit new_user_session_path
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: password
+        find_button('login-submit').click
+      end
+
+      context 'when 2FA is already enabled' do
+        before do
+          user.update!(otp_required_for_login: true, otp_secret: User.generate_otp_secret)
+        end
+
+        it 'redirects to dashboard with alert' do
+          visit new_two_factor_settings_path
+          expect(page).not_to have_current_path(new_two_factor_settings_path)
+          expect(page).to have_content('Two factor authentication is already enabled')
+          expect(page).to have_selector('.alert, .flash, [role="alert"]')
+        end
+      end
+
+      context 'when 2FA is not enabled' do
+        it 'renders the new template' do
+          visit new_two_factor_settings_path
+          expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+          expect(page).to have_content(/scan.*qr.*code/i)
+        end
+      end
+    end
+  end
+
+  describe 'GET /two_factor_settings/edit' do
+    context 'when user is not signed in' do
+      it 'redirects to sign in page' do
+        visit edit_two_factor_settings_path
+        expect(page).to have_current_path(new_user_session_path)
+        expect(page).to have_content('Sign in')
+      end
+    end
+
+    context 'when user is signed in' do
+      before do
+        visit new_user_session_path
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: password
+        find_button('login-submit').click
+      end
+
+      context 'when 2FA is not enabled' do
+        before { user.update!(otp_required_for_login: false) }
+
+        it 'redirects to new 2FA setup with alert' do
+          visit edit_two_factor_settings_path
+          expect(page).to have_current_path(new_two_factor_settings_path)
+          expect(page).to have_content('Please enable two factor authentication first')
+          expect(page).to have_selector('.alert, .flash, [role="alert"]')
+        end
+      end
+
+      context 'when 2FA is enabled' do
+        before { user.update!(otp_required_for_login: true, otp_secret: User.generate_otp_secret) }
+
+        context 'when backup codes already generated' do
+          before { user.update!(otp_backup_codes: %w[code1 code2 code3 code4 code5]) }
+
+          it 'redirects to two factor authentication page with alert' do
+            visit edit_two_factor_settings_path
+            expect(page).to have_content('You have already seen your backup codes')
+            expect(page).to have_selector('.alert, .flash, [role="alert"]')
+          end
+        end
+
+        context 'when backup codes not generated' do
+          before { user.update!(otp_backup_codes: []) }
+
+          it 'generates backup codes and renders edit' do
+            visit edit_two_factor_settings_path
+            expect(page).to have_selector('[data-testid="backup-codes-title"]')
+            codes = all('[data-testid="backup-code"]')
+            expect(codes.size).to eq(5)
+            codes.each { |el| expect(el.text).to match(/\A[a-f0-9]{32}\z/i) }
+          end
+        end
+      end
+    end
+  end
+
+  describe 'POST /two_factor_settings' do
+    before do
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find_button('login-submit').click
+      visit new_two_factor_settings_path
+    end
+
+    let(:secret) do
+      within('p', text: /please enter the following code manually/i) do
+        find('code').text
+      end
+    end
+    let(:totp) { ROTP::TOTP.new(secret) }
+
+    context 'when password is incorrect' do
+      it 'shows alert and stays on setup page' do
+        fill_in 'Code', with: totp.now
+        fill_in 'Enter your current password', with: 'wrong'
+        find('[data-testid="confirm-and-enable-two-factor"]').click
+        expect(page).to have_content('Incorrect password')
+        expect(page).to have_selector('.alert, .flash, [role="alert"]', text: /incorrect.*password/i)
+        expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+      end
+    end
+
+    context 'when password is correct' do
+      before { fill_in 'Enter your current password', with: password }
+
+      context 'when OTP code is valid' do
+        it 'enables 2FA and redirects to edit with notice' do
+          fill_in 'Code', with: totp.now
+          find('[data-testid="confirm-and-enable-two-factor"]').click
+          expect(page).to have_selector('[data-testid="two-factor-enabled-message"]')
+          expect(page).to have_selector('[data-testid="backup-codes-title"]')
+          expect(page).to have_content('Successfully enabled two factor authentication')
+        end
+      end
+
+      context 'when OTP code is invalid' do
+        it 'shows alert and stays on setup page' do
+          fill_in 'Code', with: '000000'
+          find('[data-testid="confirm-and-enable-two-factor"]').click
+          expect(page).to have_content('Incorrect Code')
+          expect(page).to have_selector('.alert, .flash, [role="alert"]', text: /incorrect.*code/i)
+          expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+        end
+      end
+    end
+  end
+
+  describe 'DELETE /two_factor_settings' do
+    before do
+      user.update!(otp_required_for_login: true, otp_secret: User.generate_otp_secret, otp_backup_codes: %w[code1 code2 code3 code4 code5])
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find_button('login-submit').click
+
+      totp = ROTP::TOTP.new(user.otp_secret)
+      fill_in 'user_otp_attempt', with: totp.now
+      find('[data-testid="otp-submit"]').click
+
+      find_link('current-user-display').click
+      find_link('configuration-menu-two-factor-authentication').click
+    end
+
+    context 'when disable_two_factor! succeeds' do
+      it 'disables 2FA and redirects to authentication page with notice' do
+        accept_confirm do
+          find('[data-testid="users_two_factor_authentication_disable"]').click
+        end
+        expect(page).to have_content('Successfully disabled two factor authentication')
+        expect(page).to have_selector('.alert, .flash, [role="alert"]')
+      end
+    end
+
+    context 'when disable_two_factor! fails' do
+      before do
+        allow_any_instance_of(User).to receive(:disable_two_factor!).and_return(false)
+      end
+
+      it 'shows alert and stays on page' do
+        accept_confirm do
+          find('[data-testid="users_two_factor_authentication_disable"]').click
+        end
+        expect(page).to have_content('Could not disable two factor authentication')
+        expect(page).to have_selector('.alert, .flash, [role="alert"]')
+      end
+    end
+  end
+
+  # 2FA有効化時の異常系（パスワード誤り・OTP誤り・空フォーム）
+  describe 'Error handling during 2FA enablement' do
+    before do
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find_button('login-submit').click
+      find_link('current-user-display').click
+      find_link('configuration-menu-two-factor-authentication').click
+      find_link('users_two_factor_authentication_enable').click
+    end
+
+    it 'shows error message when password is incorrect' do
+      # 正しいOTPコードだがパスワードを間違えて送信した場合のエラー表示
+      secret = nil
+      within('p', text: /please enter the following code manually/i) do
+        secret = find('code').text
+      end
+      totp = ROTP::TOTP.new(secret)
+      fill_in 'Code', with: totp.now
+      fill_in 'Enter your current password', with: 'wrong_password'
+      find('[data-testid="confirm-and-enable-two-factor"]').click
+      expect(page).to have_content('Incorrect password')
+      expect(page).to have_selector('.alert, .flash, [role="alert"]', text: /incorrect.*password/i)
+      expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+      expect(page).to have_content(/scan.*qr.*code/i)
+    end
+
+    it 'shows error message when OTP code is incorrect' do
+      # パスワードは正しいがOTPコードが間違っている場合のエラー表示
+      fill_in 'Code', with: '000000'
+      fill_in 'Enter your current password', with: password
+      find('[data-testid="confirm-and-enable-two-factor"]').click
+      expect(page).to have_content('Incorrect Code')
+      expect(page).to have_selector('.alert, .flash, [role="alert"]', text: /incorrect.*code/i)
+      expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+    end
+
+    it 'shows validation error when form is empty' do
+      # フォーム未入力で送信した場合のバリデーションエラー表示
+      find('[data-testid="confirm-and-enable-two-factor"]').click
+      expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+      expect(page).to have_selector('input:invalid, .error, .alert, [role="alert"]')
+    end
+  end
+
+  describe 'JavaScript error detection' do
+    before do
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find_button('login-submit').click
+    end
+
+    it 'does not have JavaScript errors on page load' do
+      # 2FA設定画面のロード時にJSエラーが発生しないこと
+      find_link('current-user-display').click
+      find_link('configuration-menu-two-factor-authentication').click
+      find_link('users_two_factor_authentication_enable').click
+      expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+      expect(page).to have_selector('input[name="two_fa[code]"]')
+      expect(page).to have_selector('input[name="two_fa[password]"]')
+      fill_in 'Code', with: '123456'
+      fill_in 'Enter your current password', with: 'test'
+      expect(find('input[name="two_fa[code]"]').value).to eq('123456')
+      expect(find('input[name="two_fa[password]"]').value).to eq('test')
+    end
+
+    it 'does not have JavaScript errors on form submit' do
+      # 2FA有効化フォーム送信時にJSエラーが発生しないこと
+      find_link('current-user-display').click
+      find_link('configuration-menu-two-factor-authentication').click
+      find_link('users_two_factor_authentication_enable').click
+      fill_in 'Code', with: '000000'
+      fill_in 'Enter your current password', with: 'wrong'
+      find('[data-testid="confirm-and-enable-two-factor"]').click
+      expect(page).to have_selector('input[name="two_fa[code]"]')
+      expect(page).to have_selector('input[name="two_fa[password]"]')
+      expect(page).to have_selector('[data-testid="confirm-and-enable-two-factor"]')
+    end
+  end
+end


### PR DESCRIPTION
5b6d4f1 でユーザー設定メニューの Turbo Frame 構造を取り除きましたが、この影響で、二要素認証の新規設定画面に於いて、確認のOTPコード+パスワード入力のフォームがありますが、これに失敗する入力をしたときの画面遷移がおかしくなっていました。コントローラは、画面をフォーム再入力のために new を render していますが、その際ブラウザに JavaScript エラーが出ており、 render されたものが描画されない状況になりました。

```
Form responses must redirect to another location
```

これは render する際に `status: :see_other` を付けないといけない状況で（ URL に変化がないので）、これをつけることでその問題は解消しましたが、そもそも Turbo Frame を取り除いたつもりがリクエストは依然 TURBO-STREAM として処理されていることが原因になっていたと言えます。

FORM がデフォルトで Turbo なので、一旦はこれを off にするように改修をしたのですが、HTML リクエストとなることで、リロードされたページはスクロール位置が最上部に戻されるため、フォームのある位置までスクロールし直さなければいけない状況になりました。これはあまりよくありません。

そこで、いちど取り除いた Turbo ですが、二要素認証のフローだけで利用することに見直しました。そもそもユーザーメニューに関する部分の Turbo Frame を取り除いた原因は言語スイッチャー（日本語|English） の部分がフレームで置き替わらないので（範囲外なので）、 Turbo Frame で実装していたユーザーメニューの表示画面と、言語スイッチャーのリンク先が一致しない問題があったためですが、二要素認証のフローだけの範囲であれば、言語スイッチャーは当該のユーザーメニューを持ち続けることになりますが、それはそれで問題ない画面遷移になります。 edit ページだけは言語スイッチャーのリンク先との不一致が起こりますが、そもそも edit ページはバックアップコードを出しており、この画面は一度表示したあとは表示しないからです（ "バックアップコードは既に表示済みです。" となり、画面はユーザーメニューの "二要素認証" /profile/two_factor_authentication へ戻される）

なお JavaScript のエラーが spec で拾えていなかったのも問題でした。当該部分は request spec しか提供できていませんでしたので、 system spec を新規に作成し、ユーザーの操作をシミュレートするようにしています。

以下は Copilot による、この PR のサマリーです：

This pull request enhances the two-factor authentication (2FA) feature by improving user experience, adding Turbo Frames for smoother navigation, updating error handling, and expanding test coverage. The changes ensure better feedback to users during 2FA setup and management, and add comprehensive system tests to validate the functionality.

### 2FA Workflow Improvements:
* Updated `app/controllers/two_factor_settings_controller.rb` to redirect users to the setup page (`new_two_factor_settings_path`) instead of rendering the same page when incorrect password or OTP code is provided. This simplifies navigation and aligns with Turbo Frame usage. [[1]](diffhunk://#diff-a5a3f8b6590613f6246dbdaffff389e196637677cea41a78343e3103a419f4fbL17-R18) [[2]](diffhunk://#diff-a5a3f8b6590613f6246dbdaffff389e196637677cea41a78343e3103a419f4fbL27-R28)
* Added Turbo Frames to `app/views/two_factor_settings/edit.html.erb` and `app/views/two_factor_settings/new.html.erb` for smoother navigation and better user experience during 2FA setup and management. [[1]](diffhunk://#diff-067d173b7235b27987e51a7431b06b3a2fef07f50b51ad1e1daffb702076a39eR1-L2) [[2]](diffhunk://#diff-067d173b7235b27987e51a7431b06b3a2fef07f50b51ad1e1daffb702076a39eR30) [[3]](diffhunk://#diff-aa8fd43e1f1b64263a3c28a39ecf857d2acd84b376c9f11d000b8929bd978003R1) [[4]](diffhunk://#diff-aa8fd43e1f1b64263a3c28a39ecf857d2acd84b376c9f11d000b8929bd978003L33-R34) [[5]](diffhunk://#diff-aa8fd43e1f1b64263a3c28a39ecf857d2acd84b376c9f11d000b8929bd978003R62)

### Localization Updates:
* Added new translation keys for 2FA-related messages in `config/locales/en.yml` and `config/locales/ja.yml`, including messages for already enabled 2FA and backup codes. This ensures proper feedback in English and Japanese. [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R125) [[2]](diffhunk://#diff-b85e8d609d1ca8ea9aef96cf26c7011d39b5dd2e7de34dd4c52d931979917508R125)

### Test Enhancements:
* Updated `spec/requests/two_factor_settings_spec.rb` to reflect changes in HTTP response status and added redirection handling for incorrect password and OTP code scenarios. [[1]](diffhunk://#diff-51fac11d8cb125504b0c63c82ee376f7b2ae1bc6ce4620623768125d3f07e2adL105-R106) [[2]](diffhunk://#diff-51fac11d8cb125504b0c63c82ee376f7b2ae1bc6ce4620623768125d3f07e2adL135-R137)
* Added comprehensive system tests in `spec/system/two_factor_settings_spec.rb` to cover various 2FA scenarios, including setup, error handling, disabling, and JavaScript error detection. These tests ensure robust validation of the 2FA feature.