### PR TITLE
言語スイッチャーのリンク先不具合の修正

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # user_confirmation POST /:locale/users/confirmation(.:format)
+  def create
+    @language_switcher_path = new_user_confirmation_path
+    super
+  end
+
+  # user_confirmation GET /:locale/users/confirmation(.:format)
+  def show
+    @language_switcher_path = new_user_confirmation_path
+    super
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # user_password POST /:locale/users/password(.:format)
+  def create
+    @language_switcher_path = new_user_password_path
+    super
+  end
+
+  # user_password PATCH /:locale/users/password(.:format)
+  # user_password PUT /:locale/users/password(.:format)
+  def update
+    @language_switcher_path = edit_user_password_path
+    super
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -9,6 +9,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  # unlink_oauth DELETE /:locale/users/oauth(.:format)
   # OAuth 認証を解除するアクション
   def unlink_oauth
     provider = params[:provider]
@@ -31,34 +32,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_edit_registration_path_for(resource)
   end
 
-  # GET /resource/sign_up
-  def new
-    @language_switcher_path = new_user_registration_path
-    super
-  end
-
-  # POST /resource
+  # user_registration POST /:locale/users(.:format)
   def create
     @language_switcher_path = new_user_registration_path
     super
   end
 
-  # GET /resource/edit
-  def edit
-    @language_switcher_path = edit_user_registration_path
-    super
-  end
-
-  # PUT /resource
+  # user_registration PATCH /:locale/users(.:format)
+  # user_registration PUT /:locale/users(.:format)
   def update
     @language_switcher_path = edit_user_registration_path
     super
   end
-
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -32,24 +32,28 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    @language_switcher_path = new_user_registration_path
+    super
+  end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    @language_switcher_path = new_user_registration_path
+    super
+  end
 
   # GET /resource/edit
-  # def edit
-  #   super
-  # end
+  def edit
+    @language_switcher_path = edit_user_registration_path
+    super
+  end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    @language_switcher_path = edit_user_registration_path
+    super
+  end
 
   # DELETE /resource
   # def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,12 +8,12 @@ class UsersController < ApplicationController
 
   # edit_profile GET /:locale/profile/edit(.:format)
   def edit
-    @language_switcher_path = edit_profile_path
   end
 
   # update_profile PATCH /:locale/profile(.:format)
   def update
     @language_switcher_path = edit_profile_path
+
     if @user.update(user_params_for_profile)
       language_changed = @user.saved_change_to_preferred_language?
       form_selected_language = params[:user][:preferred_language]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,10 +8,12 @@ class UsersController < ApplicationController
 
   # edit_profile GET /:locale/profile/edit(.:format)
   def edit
+    @language_switcher_path = edit_profile_path
   end
 
   # update_profile PATCH /:locale/profile(.:format)
   def update
+    @language_switcher_path = edit_profile_path
     if @user.update(user_params_for_profile)
       language_changed = @user.saved_change_to_preferred_language?
       form_selected_language = params[:user][:preferred_language]

--- a/app/views/shared/_language_switcher.html.erb
+++ b/app/views/shared/_language_switcher.html.erb
@@ -1,7 +1,7 @@
 <%# Show current locale and provide links to change it %>
 <div class="language-switcher flex items-center space-x-2" data-turbo="false">
   <%
-    current_path = request.path
+    current_path = @language_switcher_path || request.fullpath
     locales = LocaleConfiguration.available_locales
   %>
   <% locales.each_with_index do |locale, idx| %>

--- a/app/views/shared/_language_switcher.html.erb
+++ b/app/views/shared/_language_switcher.html.erb
@@ -1,6 +1,10 @@
 <%# Show current locale and provide links to change it %>
 <div class="language-switcher flex items-center space-x-2" data-turbo="false">
   <%
+    # When forms fail validation, controllers use `render` instead of `redirect_to`,
+    # which keeps the POST/PUT URL (e.g., /users) instead of the GET URL (e.g., /users/edit).
+    # This causes 404 errors when language switcher tries to redirect to non-existent GET routes.
+    # Controllers set @language_switcher_path to provide the correct URL for language switching.
     current_path = @language_switcher_path || request.fullpath
     locales = LocaleConfiguration.available_locales
   %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
   scope ":locale", locale: /en|ja/ do
     devise_for :users, skip: :omniauth_callbacks, controllers: {
       registrations: 'users/registrations',
-      sessions: 'users/sessions'
+      sessions: 'users/sessions',
+      passwords: 'users/passwords',
+      confirmations: 'users/confirmations'
     }
 
     devise_scope :user do

--- a/spec/system/auth/account_settings_spec.rb
+++ b/spec/system/auth/account_settings_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe 'アカウント設定', type: :system do
     it '現在のパスワードを入力して更新できること' do
       find("[data-testid='account-email']").set('new_email@example.com')
       find("[data-testid='account-current-password']").set('current_password')
-      
+
       perform_enqueued_jobs do
         find("[data-testid='account-update-submit']").click
-        
+
         expect(page).to have_content(I18n.t('devise.registrations.update_needs_confirmation'))
         expect(ActionMailer::Base.deliveries.last.to).to include('new_email@example.com')
       end
@@ -27,7 +27,7 @@ RSpec.describe 'アカウント設定', type: :system do
     it '現在のパスワードなしでは更新できないこと' do
       find("[data-testid='account-email']").set('new_email@example.com')
       find("[data-testid='account-update-submit']").click
-      
+
       expect(page).to have_content(I18n.t('errors.messages.blank'))
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe 'アカウント設定', type: :system do
       find("[data-testid='account-confirm-password']").set(new_password)
       find("[data-testid='account-current-password']").set('current_password')
       find("[data-testid='account-update-submit']").click
-      
+
       expect(page).to have_content(I18n.t('devise.registrations.updated'))
 
       # 新しいパスワードでログインできることを確認
@@ -48,7 +48,7 @@ RSpec.describe 'アカウント設定', type: :system do
       fill_in 'Email', with: user.email
       fill_in 'Password', with: new_password
       click_button I18n.t('devise.sessions.log_in')
-      
+
       expect(page).to have_content(I18n.t('devise.sessions.signed_in'))
     end
 
@@ -57,7 +57,7 @@ RSpec.describe 'アカウント設定', type: :system do
       find("[data-testid='account-confirm-password']").set('different_password')
       find("[data-testid='account-current-password']").set('current_password')
       find("[data-testid='account-update-submit']").click
-      
+
       expect(page).to have_content(I18n.t('errors.messages.confirmation', attribute: User.human_attribute_name('password')))
     end
 
@@ -66,7 +66,7 @@ RSpec.describe 'アカウント設定', type: :system do
       find("[data-testid='account-confirm-password']").set(new_password)
       find("[data-testid='account-current-password']").set('wrong_password')
       find("[data-testid='account-update-submit']").click
-      
+
       expect(page).to have_content(I18n.t('errors.messages.invalid'))
     end
   end
@@ -84,7 +84,7 @@ RSpec.describe 'アカウント設定', type: :system do
         find("[data-testid='account-link-github']").click
         expect(page).to have_content(I18n.t('devise.omniauth_callbacks.provider.linked', provider: 'GitHub'))
         expect(page).to have_selector("[data-testid='account-unlink-github']")
-        
+
         OmniAuth.config.test_mode = false
       end
     end
@@ -111,6 +111,29 @@ RSpec.describe 'アカウント設定', type: :system do
 
       expect(page).to have_current_path(edit_user_registration_path)
       expect(User.exists?(user.id)).to be true
+    end
+  end
+
+  describe '言語スイッチャーの動作' do
+    it 'バリデーションエラー時でも正しく動作すること' do
+      # 現在のパスワードなしで更新を試行（バリデーションエラー）
+      find("[data-testid='account-email']").set('new_email@example.com')
+      find("[data-testid='account-update-submit']").click
+
+      # エラーメッセージが表示される
+      expect(page).to have_content(I18n.t('errors.messages.blank'))
+
+      # 言語スイッチャーが表示されていることを確認
+      expect(page).to have_link('日本語')
+
+      # 言語を切り替え
+      click_link '日本語'
+
+      # 正しいパスにリダイレクトされる（404にならない）
+      expect(page).to have_current_path('/ja/users/edit')
+      # アカウント設定画面特有の要素が表示されることを確認
+      expect(page).to have_selector("[data-testid='account-settings-title']")
+      expect(page).to have_selector("[data-testid='account-update-submit']")
     end
   end
 end

--- a/spec/system/auth/email_confirmation_spec.rb
+++ b/spec/system/auth/email_confirmation_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe '認証メールフロー', type: :system do
 
     perform_enqueued_jobs do
       click_button I18n.t('devise.confirmations.resend_confirmation_instructions')
-      
+
       expect(page).to have_content(I18n.t('devise.confirmations.send_instructions'))
-      
+
       # メールが送信されたことを確認
       mail = ActionMailer::Base.deliveries.last
       expect(mail.to).to include(user.email)
@@ -41,17 +41,57 @@ RSpec.describe '認証メールフロー', type: :system do
     visit new_user_confirmation_path
     fill_in 'Email', with: 'nonexistent@example.com'
     click_button I18n.t('devise.confirmations.resend_confirmation_instructions')
-    
+
     expect(page).to have_content(I18n.t('errors.messages.not_found'))
   end
 
   it '既に確認済みのメールアドレスで確認メールを再送しようとするとエラーになること' do
     confirmed_user = create(:user, :confirmed)
-    
+
     visit new_user_confirmation_path
     fill_in 'Email', with: confirmed_user.email
     click_button I18n.t('devise.confirmations.resend_confirmation_instructions')
-    
+
     expect(page).to have_content(I18n.t('errors.messages.already_confirmed'))
+  end
+
+  describe '言語スイッチャーの動作' do
+    it '確認メール再送時のバリデーションエラーでも正しく動作すること' do
+      visit new_user_confirmation_path
+
+      # バリデーションエラーを発生させる（メールアドレスなし）
+      click_button I18n.t('devise.confirmations.resend_confirmation_instructions')
+
+      # エラーメッセージが表示される
+      expect(page).to have_content(I18n.t('errors.messages.blank'))
+
+      # 言語スイッチャーが表示されていることを確認
+      expect(page).to have_link('日本語')
+
+      # 言語を切り替え
+      click_link '日本語'
+
+      # 正しいパスにリダイレクトされる（404にならない）
+      expect(page).to have_current_path('/ja/users/confirmation/new')
+      expect(page).to have_button('確認メールを再送')
+    end
+
+    it '無効なトークンでのメール確認失敗でも正しく動作すること' do
+      # 無効なトークンでアクセス
+      visit user_confirmation_path(confirmation_token: 'invalid_token')
+
+      # エラーメッセージが表示される
+      expect(page).to have_content(I18n.t('errors.messages.invalid'))
+
+      # 言語スイッチャーが表示されていることを確認
+      expect(page).to have_link('日本語')
+
+      # 言語を切り替え
+      click_link '日本語'
+
+      # 正しいパスにリダイレクトされる（404にならない）
+      expect(page).to have_current_path('/ja/users/confirmation/new')
+      expect(page).to have_button('確認メールを再送')
+    end
   end
 end

--- a/spec/system/user_profile_spec.rb
+++ b/spec/system/user_profile_spec.rb
@@ -147,4 +147,29 @@ RSpec.describe 'User profile editing', type: :system do
       expect(user.reload.preferred_language).to eq('en')
     end
   end
+
+  describe 'Language switcher during validation errors' do
+    it 'works correctly when profile update fails' do
+      visit edit_profile_path
+
+      # バリデーションエラーを発生させる
+      fill_in 'Username', with: ''
+      click_button 'Update'
+
+      # エラーメッセージが表示される
+      expect(page).to have_content("Username can't be blank")
+
+      # 言語スイッチャーが表示されていることを確認
+      expect(page).to have_link('日本語')
+
+      # 言語を切り替え
+      click_link '日本語'
+
+      # 正しいパスにリダイレクトされる（404にならない）
+      expect(page).to have_current_path('/ja/profile/edit')
+      # プロフィール編集画面特有の要素が表示されることを確認
+      expect(page).to have_selector("[data-testid='account-preferred-language']")
+      expect(page).to have_field('ユーザー名')
+    end
+  end
 end

--- a/spec/system/user_registration_spec.rb
+++ b/spec/system/user_registration_spec.rb
@@ -80,4 +80,28 @@ RSpec.describe 'User registration', type: :system do
       expect_error_message(User, :email, :blank)
     end
   end
+
+  context '言語スイッチャーの動作' do
+    it 'バリデーションエラー時でも正しく動作すること' do
+      visit new_user_registration_path
+
+      # バリデーションエラーを発生させる
+      find('[data-testid="signup-submit"]').click
+
+      # エラーメッセージが表示される
+      expect(page).to have_content("can't be blank")
+
+      # 言語スイッチャーが表示されていることを確認
+      expect(page).to have_link('日本語')
+
+      # 言語を切り替え
+      click_link '日本語'
+
+      # 正しいパスにリダイレクトされる（404にならない）
+      expect(page).to have_current_path('/ja/users/sign_up')
+      # 登録画面特有の要素が表示されることを確認
+      expect(page).to have_selector('[data-testid="signup-title"]')
+      expect(page).to have_selector('[data-testid="signup-submit"]')
+    end
+  end
 end


### PR DESCRIPTION
#31 の対応です。 PUT アクションの後に render される場合に URL が正しくなくなり、言語スイッチャーのリンク先と一致しなくなる問題を修正します。

devise のコントローラは [responders](https://github.com/heartcombo/responders/tree/v3.1.1) によるレスポンス処理をしているらしく、その `respond_with` によって、成功時は redirect 失敗時は render といった処理分けがされているようです。したがって devise のコントローラはだいたいオーバーライドが必要になります。
