### PR TITLE
ビューのメンテナンス

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,7 @@
 module UsersHelper
   def users_frame(title_key, &block)
-    render 'users/frame_layout', title: t(title_key), &block
+    title = t(title_key)
+    testid = [title_key.gsub('.', '-'), 'title'].join('-')
+    render 'users/frame_layout', title: title, testid: testid, &block
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,8 +1,4 @@
-<div class="container p-4">
-  <%= content_tag :h2, t('devise.registrations.account_settings'), class: 'text-2xl font-bold mb-4', **data_with_testid('account-settings-title') %>
-
-  <%= render "shared/flash" %>
-
+<%= users_frame('devise.registrations.account_settings') do %>
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
     <%= render "shared/error_messages", resource: resource %>
 
@@ -141,8 +137,9 @@
         class: "text-white bg-red-600 hover:bg-red-700 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center",
         **data_with_testid('account-cancel',
           turbo_confirm: t('devise.registrations.cancel_confirm'),
+          turbo_frame: '_top',
         ),
       )
     %>
   </div>
-</div>
+<% end %>

--- a/app/views/two_factor_settings/edit.html.erb
+++ b/app/views/two_factor_settings/edit.html.erb
@@ -1,9 +1,4 @@
-<turbo-frame id="tfa-settings">
-<div class="container p-4">
-  <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-4', **data_with_testid('two-factor-enabled-message') %>
-
-  <%= render 'shared/flash' %>
-
+<%= users_frame('devise.sessions.two_factor_settings.title') do %>
   <p class="text-sm text-gray-500 mb-4">
     <%= t('devise.sessions.two_factor_settings.enabled') %>
   </p>
@@ -26,5 +21,4 @@
       </div>
     </div>
   </div>
-</div>
-</turbo-frame>
+<% end %>

--- a/app/views/two_factor_settings/new.html.erb
+++ b/app/views/two_factor_settings/new.html.erb
@@ -1,7 +1,4 @@
-<turbo-frame id="tfa-settings">
-<div class="container p-4">
-  <%= content_tag :h2, t('devise.sessions.two_factor_settings.title'), class: 'text-2xl font-bold mb-6', **data_with_testid('two-factor-enabled-message') %>
-
+<%= users_frame('devise.sessions.two_factor_settings.title') do %>
   <ol class="list-decimal pl-5 space-y-6">
     <%= content_tag :li, **data_with_testid('configuration-menu-two-factor-authentication') do %>
       <div>
@@ -58,5 +55,5 @@
       </div>
     </li>
   </ol>
-</div>
-</turbo-frame>
+ <% end %>
+ 

--- a/app/views/users/_frame_layout.html.erb
+++ b/app/views/users/_frame_layout.html.erb
@@ -1,9 +1,16 @@
-<div class="container p-4">
-  <h2 class="text-2xl font-bold mb-4"><%= title %></h2>
+<turbo-frame id="users-frame">
+  <div class="container p-4">
+    <%=
+      content_tag(:h2, title,
+        class: 'text-2xl font-bold mb-4',
+        **data_with_testid(testid)
+      )
+    %>
 
-  <%= render 'shared/flash' %>
+    <%= render 'shared/flash' %>
 
-  <div>
-    <%= yield %>
+    <div>
+      <%= yield %>
+    </div>
   </div>
-</div>
+</turbo-frame>

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UsersHelper, type: :helper do
   describe '#users_frame' do
     it '指定したタイトルキーで部分テンプレートを描画する' do
       allow(helper).to receive(:t).with('users.title').and_return('タイトル')
-      expect(helper).to receive(:render).with('users/frame_layout', title: 'タイトル')
+      expect(helper).to receive(:render).with('users/frame_layout', title: 'タイトル', testid: 'users-title-title')
       helper.users_frame('users.title') {}
     end
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -46,7 +46,7 @@ end
 # Capybara 設定
 Capybara.configure do |config|
   config.test_id = 'data-testid'
-  config.default_max_wait_time = 10
+  config.default_max_wait_time = 2
   config.default_normalize_ws = true
 
   if ENV['DOCKER'].present?

--- a/spec/system/auth/account_settings_spec.rb
+++ b/spec/system/auth/account_settings_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'アカウント設定', type: :system do
       # 正しいパスにリダイレクトされる（404にならない）
       expect(page).to have_current_path('/ja/users/edit')
       # アカウント設定画面特有の要素が表示されることを確認
-      expect(page).to have_selector("[data-testid='account-settings-title']")
+      expect(page).to have_selector("[data-testid='devise-registrations-account_settings-title']")
       expect(page).to have_selector("[data-testid='account-update-submit']")
     end
   end

--- a/spec/system/two_factor_enable_spec.rb
+++ b/spec/system/two_factor_enable_spec.rb
@@ -34,10 +34,158 @@ RSpec.describe '2FA有効化フロー', type: :system do
     fill_in 'Enter your current password', with: password
     find('[data-testid="confirm-and-enable-two-factor"]').click
 
-    expect(page).to have_selector('[data-testid="two-factor-enabled-message"]')
+    expect(page).to have_selector('[data-testid="devise-sessions-two_factor_settings-title-title"]')
     expect(page).to have_selector('[data-testid="backup-codes-title"]')
 
     codes = all_testid('backup-code').map { |elem| elem.text }.select { |text| text.match?(/\A[a-f0-9]{32}\z/i) }
     expect(codes.size).to eq(5)
+  end
+
+  it '2FAを無効化できる' do
+    # まず2FAを有効化
+    user.update!(otp_required_for_login: true, otp_secret: User.generate_otp_secret, otp_backup_codes: %w[code1 code2 code3 code4 code5])
+
+    # ログイン
+    visit new_user_session_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: password
+    find('[data-testid="login-submit"]').click
+
+    # 2FAコード入力
+    totp = ROTP::TOTP.new(user.otp_secret)
+    fill_in 'user_otp_attempt', with: totp.now
+    find('[data-testid="otp-submit"]').click
+
+    # 右上のユーザ名クリック
+    find('[data-testid="current-user-display"]').click
+
+    # 左のメニューをクリック
+    find('[data-testid="configuration-menu-two-factor-authentication"]').click
+
+    # 無効化ボタン押下（確認ダイアログで承認）
+    accept_confirm do
+      find('[data-testid="users_two_factor_authentication_disable"]').click
+    end
+
+    # 無効化完了のメッセージが表示されることを確認
+    expect(page).to have_content('Successfully disabled two factor authentication')
+    expect(page).to have_selector('.alert, .flash, [role="alert"]')
+
+    # 2FA設定ページで有効化ボタンが表示されることを確認（無効化されたことの証明）
+    expect(page).to have_selector('[data-testid="users_two_factor_authentication_enable"]')
+  end
+
+  describe 'バックアップコードでのログイン' do
+    before do
+      # 2FAを有効化して、画面に表示されるバックアップコードを取得
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find('[data-testid="login-submit"]').click
+
+      find('[data-testid="current-user-display"]').click
+      find('[data-testid="configuration-menu-two-factor-authentication"]').click
+      find('[data-testid="users_two_factor_authentication_enable"]').click
+
+      secret = nil
+      within('p', text: /please enter the following code manually/i) do
+        secret = find('code').text
+      end
+      totp = ROTP::TOTP.new(secret)
+      code = totp.now
+
+      fill_in 'Code', with: code
+      fill_in 'Enter your current password', with: password
+      find('[data-testid="confirm-and-enable-two-factor"]').click
+
+      # 画面に表示されたバックアップコードを取得
+      @displayed_backup_codes = all('[data-testid="backup-code"]').map(&:text)
+
+      # ログアウトして、バックアップコードでのログインテスト準備
+      find('[data-testid="current-user-signout"]').click
+    end
+
+    it 'バックアップコードでログインできる' do
+      # 表示されたバックアップコードの最初のものを使用
+      first_backup_code = @displayed_backup_codes.first
+
+      # ログイン
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find('[data-testid="login-submit"]').click
+
+      # 2FAページが表示されることを確認
+      expect(page).to have_selector('[data-testid="otp-input"]')
+      expect(page).to have_selector('[data-testid="otp-submit"]')
+
+      # バックアップコードでログイン
+      fill_in 'user_otp_attempt', with: first_backup_code
+      find('[data-testid="otp-submit"]').click
+
+      # ログイン成功を確認
+      expect(page).to have_content('Signed in successfully')
+    end
+
+    it 'バックアップコードは一度使うと使えなくなる' do
+      first_backup_code = @displayed_backup_codes.first
+      second_backup_code = @displayed_backup_codes.second
+
+      # 1回目のログイン（成功）
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find('[data-testid="login-submit"]').click
+
+      fill_in 'user_otp_attempt', with: first_backup_code
+      find('[data-testid="otp-submit"]').click
+
+      expect(page).to have_content('Signed in successfully')
+
+      # ログアウト
+      find('[data-testid="current-user-signout"]').click
+
+      # 2回目のログイン（同じバックアップコードで失敗）
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find('[data-testid="login-submit"]').click
+
+      fill_in 'user_otp_attempt', with: first_backup_code
+      find('[data-testid="otp-submit"]').click
+
+      # エラーメッセージが表示される
+      expect(page).to have_content('Invalid authentication code')
+      expect(page).to have_selector('[data-testid="otp-input"]')
+
+      # 別のバックアップコードなら使える
+      fill_in 'user_otp_attempt', with: second_backup_code
+      find('[data-testid="otp-submit"]').click
+
+      expect(page).to have_content('Signed in successfully')
+    end
+
+    it 'バックアップコードを使用後、残りのコード数が減る' do
+      first_backup_code = @displayed_backup_codes.first
+
+      # 使用前のバックアップコード数を確認
+      user.reload
+      initial_codes_count = user.otp_backup_codes.length
+
+      # バックアップコードでログイン
+      visit new_user_session_path
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: password
+      find('[data-testid="login-submit"]').click
+
+      fill_in 'user_otp_attempt', with: first_backup_code
+      find('[data-testid="otp-submit"]').click
+
+      expect(page).to have_content('Signed in successfully')
+
+      # データベースでバックアップコード数が減っていることを確認
+      user.reload
+      expect(user.otp_backup_codes.length).to eq(initial_codes_count - 1)
+    end
   end
 end

--- a/spec/system/two_factor_settings_spec.rb
+++ b/spec/system/two_factor_settings_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'TwoFactorSettings', type: :system do
         it 'enables 2FA and redirects to edit with notice' do
           fill_in 'Code', with: totp.now
           find('[data-testid="confirm-and-enable-two-factor"]').click
-          expect(page).to have_selector('[data-testid="two-factor-enabled-message"]')
+          expect(page).to have_selector('[data-testid="devise-sessions-two_factor_settings-title-title"]')
           expect(page).to have_selector('[data-testid="backup-codes-title"]')
           expect(page).to have_content('Successfully enabled two factor authentication')
         end


### PR DESCRIPTION
#32 の対応中に、関連箇所で気になっていた箇所を整理します。

- 2FA の turbo-frame は専用のidを振っていましたが、 users-frame で統一してよいのでそうしました。このフレームは、左側のユーザ設定メニューを開いた右側のコンテンツ内で使うフレームで、左側のメニュー項目から呼ぶためのものではありません。
- それに関係して、 UsersHelper にある users/frame_layout を利用するようにします。 testid が変わるので変更しています。
- 2FA のバックアップコードでのログインのテストがなかったので Claude Sonnet 4 に追加してもらいます。
- Capybara の default_max_wait_time を 2 に戻しました。 10 はたとえ要素の表示までに必要な秒数だったとしても長すぎます。