### PR TITLE
OAuth 連携の不具合修正

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -3,4 +3,9 @@ class Authorization < ApplicationRecord
 
   validates :provider, :uid, presence: true
   validates :uid, uniqueness: { scope: :provider }
+  validates :provider, uniqueness: { scope: :user_id }
+
+  def self.provider_uid_exists?(provider, uid)
+    where(provider: provider, uid: uid).exists?
+  end
 end

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -1,31 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe Authorization, type: :model do
-  describe 'バリデーション' do
-    it 'provider, uid, user があれば有効' do
+describe 'Validations' do
+    it 'does not allow duplicate provider/uid pair even for different users' do
+      # provider, uid のペアはユーザーが違っても重複できない
+      user1 = create(:user)
+      user2 = create(:user)
+      create(:authorization, user: user1, provider: 'github', uid: 'uid1')
+      dup = build(:authorization, user: user2, provider: 'github', uid: 'uid1')
+      expect(dup).not_to be_valid
+      expect(dup.errors[:uid]).to include('has already been taken')
+    end
+
+    it 'allows same user and uid if provider is different' do
+      # 同じユーザー・uidでもproviderが違えば登録できる
+      user = create(:user)
+      create(:authorization, user: user, provider: 'github', uid: 'uid1')
+      auth = build(:authorization, user: user, provider: 'twitter', uid: 'uid1')
+      expect(auth).to be_valid
+    end
+
+    it 'does not allow duplicate user/provider pair' do
+      # 同じユーザー・providerの組み合わせは一意でなければならない
+      user = create(:user)
+      create(:authorization, user: user, provider: 'github', uid: 'uid1')
+      dup = build(:authorization, user: user, provider: 'github', uid: 'uid2')
+      expect(dup).not_to be_valid
+      expect(dup.errors[:provider]).to include('has already been taken')
+    end
+
+    it 'is valid with provider, uid, and user' do
       auth = build(:authorization)
       expect(auth).to be_valid
     end
 
-    it 'provider がなければ無効' do
+    it 'is invalid without provider' do
       auth = build(:authorization, provider: nil)
       expect(auth).not_to be_valid
       expect(auth.errors[:provider]).to be_present
     end
 
-    it 'uid がなければ無効' do
+    it 'is invalid without uid' do
       auth = build(:authorization, uid: nil)
       expect(auth).not_to be_valid
       expect(auth.errors[:uid]).to be_present
     end
 
-    it 'user がなければ無効' do
+    it 'is invalid without user' do
       auth = build(:authorization, user: nil)
       expect(auth).not_to be_valid
       expect(auth.errors[:user]).to be_present
     end
 
-    it '同じ provider, uid の組み合わせは一意でなければならない' do
+    it 'does not allow duplicate provider/uid pair' do
+      # provider, uid の組み合わせは一意でなければならない
       existing = create(:authorization, provider: 'github', uid: '123')
       dup = build(:authorization, provider: 'github', uid: '123')
       expect(dup).not_to be_valid

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -28,25 +28,67 @@ RSpec.describe 'OmniauthCallbacks', type: :request do
     context 'when user is signed in and not yet linked' do
       before { sign_in user }
 
-      it 'links the provider and redirects with success message' do
+      it 'creates a new authorization record for the user' do
         expect {
           get user_github_omniauth_callback_path
         }.to change { user.authorizations.count }.by(1)
+      end
+
+      it 'redirects to the edit registration page after linking' do
+        get user_github_omniauth_callback_path
         expect(response).to redirect_to(edit_user_registration_path)
-        follow_redirect!
-        # flashメッセージはTurbo/redirect後のHTMLには含まれない場合があるため、flash[:notice]で検証
-        expect(flash[:notice]).to eq(I18n.t('devise.omniauth_callbacks.provider.linked', provider: 'GitHub'))
       end
     end
 
-    context 'when user is signed in and already linked with different uid' do
+    context 'when user is signed in and already linked with same uid (self-link)' do
       before do
-        user.authorizations.create!(provider: provider, uid: 'other_uid')
+        user.authorizations.create!(provider: provider, uid: uid)
         sign_in user
       end
 
-      it 'does not link and redirects with already_linked message' do
-        get user_github_omniauth_callback_path
+      it 'does not create a new authorization and shows already_linked alert (self-link)' do
+        expect {
+          get user_github_omniauth_callback_path
+        }.not_to change { user.authorizations.count }
+        expect(response).to redirect_to(edit_user_registration_path)
+        follow_redirect!
+        expect(flash[:alert]).to eq(I18n.t('devise.omniauth_callbacks.provider.already_linked', provider: 'GitHub'))
+      end
+    end
+
+    context 'when user is signed in and another user already linked with same provider/uid' do
+      let!(:other_user) { create(:user, :confirmed) }
+      before do
+        other_user.authorizations.create!(provider: provider, uid: uid)
+        sign_in user
+      end
+
+      it 'does not create a new authorization and shows already_linked alert (other user)' do
+        expect {
+          get user_github_omniauth_callback_path
+        }.not_to change { user.authorizations.count }
+        expect(response).to redirect_to(edit_user_registration_path)
+        follow_redirect!
+        expect(flash[:alert]).to eq(I18n.t('devise.omniauth_callbacks.provider.already_linked', provider: 'GitHub'))
+      end
+    end
+
+    context 'when user is signed in and link_with triggers a validation error (race condition)' do
+      before do
+        sign_in user
+        # Simulate race: provider_uid_exists? returns false, but link_with fails due to validation
+        allow(Authorization).to receive(:provider_uid_exists?).and_return(false)
+        allow_any_instance_of(User).to receive(:link_with).and_wrap_original do |m, *args|
+          auth = m.receiver.authorizations.build(provider: args[0], uid: args[1])
+          auth.errors.add(:uid, 'has already been taken')
+          auth
+        end
+      end
+
+      it 'does not create a new authorization and shows already_linked alert if link_with fails validation' do
+        expect {
+          get user_github_omniauth_callback_path
+        }.not_to change { user.authorizations.count }
         expect(response).to redirect_to(edit_user_registration_path)
         follow_redirect!
         expect(flash[:alert]).to eq(I18n.t('devise.omniauth_callbacks.provider.already_linked', provider: 'GitHub'))
@@ -71,8 +113,8 @@ RSpec.describe 'OmniauthCallbacks', type: :request do
       end
     end
 
-    describe '既存ユーザーがOmniAuthでサインインした場合' do
-      it 'root_pathにリダイレクトされる' do
+    describe 'when an existing user signs in via OmniAuth' do
+      it 'redirects to root_path' do
         existing_user = create(:user, :confirmed)
         allow(User).to receive(:from_omniauth).and_return(existing_user)
         allow(existing_user).to receive(:persisted?).and_return(true)
@@ -84,16 +126,14 @@ RSpec.describe 'OmniauthCallbacks', type: :request do
   end
 
   describe 'GET /users/auth/failure' do
-    it 'redirects to sign in with failure message' do
-      # OmniAuth失敗パスはロケールスコープ外なのでロケールなしでアクセス
+    it 'redirects to sign in with failure message (unknown provider)' do
       get '/users/auth/failure'
       expect(response).to redirect_to(new_user_session_path(locale: 'en'))
       follow_redirect!
       expect(flash[:alert]).to eq(I18n.t('devise.omniauth_callbacks.failure', kind: I18n.t('devise.omniauth_callbacks.unknown_provider')))
     end
 
-    it 'handles auth_failure action correctly' do
-      # failureアクションの正常な動作を確認
+    it 'redirects to sign in on auth_failure action' do
       get '/users/auth/failure'
       expect(response).to redirect_to(new_user_session_path(locale: 'en'))
     end


### PR DESCRIPTION
OAuth 連携時に、すでに他のユーザに連携されていた場合には Authorization モデルのほうでバリデーションエラーとなるため、データは更新されないのですが、画面の flash は連携が成功したと表示されていました。

その修正でロジックを見直していた中で、ユーザが同一のproviderの複数のレコードを持ててしまっていることに気がつき、その修正も加えました。

また念の為ログを多めに書き出すようにしています。

以下は Copilot によるサマリーです：

This pull request enhances the handling of user authorization linking in the OmniAuth callbacks and improves test coverage. The key changes include stricter validation rules for `Authorization` records, improved logging for potential conflicts, and expanded test cases to cover edge scenarios.

### Enhancements to Authorization Logic:
* Updated `link_provider_or_alert` in `OmniAuthCallbacksController` to handle cases where a provider/UID pair is already linked to another user, adding warnings and detailed logging for conflicts.
* Added a new validation to enforce the uniqueness of the `provider` scoped to `user_id` in the `Authorization` model.
* Introduced a new class method `provider_uid_exists?` in the `Authorization` model to check for existing provider/UID pairs.

### Improvements to Test Coverage:
* Expanded `Authorization` model tests to validate new constraints, including duplicate provider/UID pairs across users and duplicate user/provider pairs.
* Enhanced request specs for OmniAuth callbacks to verify behavior in edge cases, such as self-linking, linking with a provider/UID already linked to another user, and handling race conditions during linking. [[1]](diffhunk://#diff-b175cb520b316cea2754c90273d0fa0fc9f18424afeea7a370fa2b734be2b88dL31-R91) [[2]](diffhunk://#diff-b175cb520b316cea2754c90273d0fa0fc9f18424afeea7a370fa2b734be2b88dL74-R117)

### Test Cleanup and Refactoring:
* Refactored existing test descriptions and structure for clarity and consistency, replacing Japanese comments with English for broader accessibility. [[1]](diffhunk://#diff-b7c13b23d47e4f2f7061baeea9d0ac76ab8bd3176cc0c170a2d9b850266a6c20L4-R56) [[2]](diffhunk://#diff-b175cb520b316cea2754c90273d0fa0fc9f18424afeea7a370fa2b734be2b88dL87-R136)