### PR TITLE
seed データの初期パスワード修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,10 +9,17 @@
 #   end
 
 unless User.exists?(email: 'admin@localhost', admin: true)
+  password =
+    if Rails.env.production?
+      SecureRandom.urlsafe_base64(16)
+    else
+      'YOU MUST CHANGE THIS'
+    end
+
   User.create!(
     email: 'admin@localhost',
     username: 'adminuser',
-    password: 'YOU MUST CHANGE THIS',
+    password: password,
     admin: true,
     confirmed_at: Time.current
   )


### PR DESCRIPTION
production 環境では、手順書のとおりにパスワードを変更できるとは限らず（ Rails コンソールを開くべきではない）初期値は安全なものにしておくべきです。

以下は Copilot さんによるサマリーです

This pull request improves the security of the default admin user creation in the `db/seeds.rb` file by introducing environment-aware password generation.

Security enhancements:

* The admin user's password is now set to a securely generated random value in production environments, while in development and test environments, it remains a placeholder that must be changed.
