### PR TITLE
プレビューできない添付ファイルも、メッセージ内にアイコンとして表示する

### DIFF
--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -30,7 +30,7 @@
       <% message.attachements.each do |att| %>
         <div class="container flex-shrink-0 w-auto mx-2">
           <% if att.representable? %>
-            <div class="h-40 w-40 bg-gray-200 flex" data-action="click->messages#changePreview">
+            <div class="my-2 h-40 w-40 bg-gray-200 flex cursor-pointer" data-action="click->messages#changePreview">
               <% if ['video/quicktime', 'video/mp4'].include?(att.content_type) %>
                 <div class="relative">
                 <%= video_tag([rails_blob_path(att)],
@@ -57,6 +57,17 @@
                   )
                 %>
               <% end %>
+            </div>
+          <% else %>
+            <div class="my-2 h-40 w-40 bg-gray-200 flex">
+              <%# TODO: ほかの SVG の箇所も併せて、ヘルパーにしてください %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#333333" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                <polyline points="14 2 14 8 20 8"/>
+                <text x="12" y="20" text-anchor="middle" font-size="4" font-weight="100">
+                  <%= att.content_type.split('/').last %>
+                </text>
+              </svg>
             </div>
           <% end %>
 


### PR DESCRIPTION
投稿メッセージに添付ファイルがある場合に、それがプレビューできないファイルタイプの場合は、投稿されたメッセージの中でその存在が気づきづらいため、ファイルのアイコンを表示するようにします。

以下は Copilot さんによるサマリーです

This pull request improves the display of message attachments in the `app/views/messages/_message.html.erb` view. It enhances the UI for both representable and non-representable attachments, adding visual cues and better handling for unsupported file types.

**Attachment display improvements:**

* Added a `cursor-pointer` class to the attachment preview container for representable attachments, making it clear that the element is clickable.
* Added a new SVG-based placeholder for non-representable attachments, displaying the file type extension and including a TODO comment suggesting future refactoring to a helper.