### PR TITLE
smtp_settings の設定を堅牢にする

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -73,9 +73,6 @@ services:
       ANNABELLE_VARIANT_PROCESSOR: vips
       SMTP_ADDRESS: smtp
       SMTP_PORT: 1025
-      SMTP_DOMAIN:
-      SMTP_USERNAME:
-      SMTP_PASSWORD:
       APP_HTTP_HOST: 127.0.0.1
       APP_HTTP_PORT: 3000
       APP_HTTP_PROTOCOL: http

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = false
 
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
@@ -45,13 +45,15 @@ Rails.application.configure do
   }
 
   # Specify outgoing SMTP server.
+  # NOTE: user_name に空文字を渡すのと、nil を渡すのとでは挙動が異なります。
+  # nil では ArgumentError (SMTP-AUTH requested but missing user name) 例外になります。
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:              ENV['SMTP_ADDRESS'].presence || 'localhost',
     port:                 ENV['SMTP_PORT'].presence || 1025,
-    domain:               ENV['SMTP_DOMAIN'], # HELO
-    user_name:            ENV['SMTP_USERNAME'],
-    password:             ENV['SMTP_PASSWORD'],
+    domain:               ENV['SMTP_DOMAIN'].presence || '',
+    user_name:            ENV['SMTP_USERNAME'].presence || '',
+    password:             ENV['SMTP_PASSWORD'].presence || '',
     authentication:       :plain,
     enable_starttls_auto: true
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,9 +68,9 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address:              ENV['SMTP_ADDRESS'].presence || 'localhost',
     port:                 ENV['SMTP_PORT'].presence || 587,
-    domain:               ENV['SMTP_DOMAIN'], # HELO
-    user_name:            ENV['SMTP_USERNAME'],
-    password:             ENV['SMTP_PASSWORD'],
+    domain:               ENV['SMTP_DOMAIN'].presence || '',
+    user_name:            ENV['SMTP_USERNAME'].presence || '',
+    password:             ENV['SMTP_PASSWORD'].presence || '',
     authentication:       :plain,
     enable_starttls_auto: true
   }


### PR DESCRIPTION
config.action_mailer.smtp_settings のところで、キー username に空文字を渡すのと、nil を渡すのとでは挙動が異なります。 nil では `ArgumentError (SMTP-AUTH requested but missing user name)` 例外になります。

環境変数から設定するように設計しているので、環境変数自体を省略した時に nil になってしまい、開発環境では値が必要ないのに指定しなければならない状況でした。

（これまでに二度のやらかしを経験したのでソースコードにコメントを書き入れました）

以下は Copilot さんによるサマリーです

This pull request updates the mailer SMTP configuration to handle missing environment variables more gracefully and clarifies the behavior when SMTP credentials are unset. The changes ensure that empty strings are used instead of nil for certain SMTP settings, preventing runtime errors, and improve documentation for future maintainers.

**Mailer SMTP configuration improvements:**

* Updated `config.action_mailer.smtp_settings` in both `config/environments/development.rb` and `config/environments/production.rb` to use `.presence || ''` for `domain`, `user_name`, and `password` so that empty strings are passed if the corresponding environment variables are missing, avoiding `ArgumentError` exceptions when values are nil. [[1]](diffhunk://#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47R48-R56) [[2]](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL71-R73)
* Added a comment in `config/environments/development.rb` explaining the difference between passing an empty string and nil to `user_name`, and the resulting error if nil is used.

**Configuration file cleanup:**

* Removed unused `SMTP_DOMAIN`, `SMTP_USERNAME`, and `SMTP_PASSWORD` environment variable lines from the `services:` section in `compose.yml` to reflect that they are now optional and handled in code.
* Commented out the `config.action_mailer.raise_delivery_errors = false` line in `config/environments/development.rb`, possibly to allow for easier toggling or to rely on the default.