### PR TITLE
Coveralls がダウンしていると CI が FAIL になる問題の修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,17 @@ jobs:
           name: coverage-report
           path: coverage/
 
+      - name: Check Coveralls availability
+        id: coveralls_check
+        run: |
+          if curl -sSf https://coveralls.io > /dev/null; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Coveralls GitHub Action
+        if: steps.coveralls_check.outputs.available == 'true'
         uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/hiroaki/Annabelle/badge.svg?branch=develop)](https://coveralls.io/github/hiroaki/Annabelle?branch=develop)
+![Coveralls](https://img.shields.io/coverallsCoverage/github/hiroaki/Annabelle?branch=develop)
 
 # Annabelle / アナベル
 


### PR DESCRIPTION
RSpec のテストの後にコードカバレッジを Coveralls に push しますが、 Coveralls がダウンしていると CI が FAIL になります。
その対処として、 Coveralls が使えるかどうかを事前にチェックして、使えない場合は Coveralls をスキップするようにします。

This pull request introduces a small improvement to the CI workflow to make the Coveralls integration more robust, and updates the coverage badge in the `README.md`.

CI/CD improvements:

* Added a step in the `.github/workflows/ci.yml` workflow to check if Coveralls is available before running the Coveralls GitHub Action, preventing failures if Coveralls is down.

Documentation updates:

* Updated the coverage badge in `README.md` to use the shields.io badge instead of the default Coveralls badge.