### PR TITLE
CI - ワークフローの見直し

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,7 @@ jobs:
 
       - name: Set up database
         run: |
-          bin/rails db:create
-          bin/rails db:schema:load
-          bin/rails db:seed
+          bin/rails db:prepare
 
       - name: Precompile assets
         run: bin/rails assets:precompile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,10 @@ jobs:
 
       - name: Install Google Chrome
         run: |
-          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'
+          wget -O- https://dl.google.com/linux/linux_signing_key.pub | \
+            gpg --dearmor | sudo tee /usr/share/keyrings/google-chrome.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | \
+            sudo tee /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y google-chrome-stable
 


### PR DESCRIPTION
CI ワークフローを全体的に GPT-4.1 に見直してもらい、次の二点についてのみ修正します：
- Chorme ブラウザのインストール中の `apt-key` は非推奨とのことなので、置き換えます。
- データベースのセットアップは `db:prepare` することだけにするように修正します。

This pull request updates the CI workflow configuration to improve security and streamline Rails database setup. The main changes are:

**CI Workflow Security and Maintenance:**

* Updated the Google Chrome installation step to use a more secure method for adding the signing key, replacing `apt-key` (now deprecated) with `gpg --dearmor` and the `signed-by` option in the repository source list.

**Rails Setup Simplification:**

* Replaced separate Rails database setup commands (`db:create`, `db:schema:load`, `db:seed`) with the single `bin/rails db:prepare` command for a more concise and reliable setup.