### PR TITLE
開発環境用 Docker Compose の調整

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -e
 
-echo "Preparing database..."
-./bin/rails db:prepare
-
-if [ "$RAILS_ENV" != "production" ] && [ "$RAILS_ENV" != "staging" ]; then
+if [ "$RAILS_ENV" = "development" ]; then
+  echo "[docker-entrypoint] Skipping db:prepare in development. Please run manually if needed."
   mkdir -p log tmp
   ./bin/rails tailwindcss:build
+else
+  echo "Preparing database..."
+  ./bin/rails db:prepare
 fi
 
 exec "$@"

--- a/compose.yml
+++ b/compose.yml
@@ -80,8 +80,11 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/rails
       - bundle:/usr/local/bundle
+      - .:/rails
+      - tmp:/rails/tmp
+      - log:/rails/log
+      - storage:/rails/storage
     tty: true
     stdin_open: true
     depends_on:
@@ -95,3 +98,6 @@ services:
 
 volumes:
   bundle:
+  tmp:
+  log:
+  storage:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -38,7 +38,21 @@ $ docker compose exec web bash
 
 ### A-3. Run rails commands inside the container / コンテナ内で rails コマンドを実行
 
+Before running the application, make sure to set the required environment variables. Most essential settings are already configured at build time, but please refer to [/docs/ENVIRONMENT_VARIABLES.md](/docs/ENVIRONMENT_VARIABLES.md) for details.
+
 実行に必要な設定は環境変数から設定します。起動の前に設定してください。最低限の設定内容はビルド時に設定されています。詳しくは [/docs/ENVIRONMENT_VARIABLES.md](/docs/ENVIRONMENT_VARIABLES.md) を参照してください。
+
+On the first run, set up the database manually as follows:
+
+初回は、データベースのセットアップを行ってください。
+
+```
+> bin/rails db:prepare
+```
+
+Depending on your development needs, you can run any Rails command inside the container, such as starting the server or running migrations.
+
+開発状況に応じて、サーバーの起動やマイグレーションなど、任意の rails コマンドをコンテナ内で実行します。
 
 ```
 # Start the server


### PR DESCRIPTION
- データベースの操作は任意のタイミングに行えるようにする

開発環境において、開発者が任意のタイミングで `db:migrate` を行えるように、 entrypoint の中で暗黙のうちに実行していた `db:prepare` をしないようにします。

- コンテナ側から書き込みがあるディレクトリは、名前付きボリュームにする

bind-mount したボリュームのファイルのパーミッションの問題があるので、コンテナ側から書き込みがあるディレクトリは、名前付きボリュームにします。

macOS 用の Docker Desktop では、コンテナ側で作ったファイルの owner が、ホスト上ではそのホスト自身(Dockerを実行している)ユーザのuidになるようです。

たとえば現在の設定ではコンテナは ユーザ "rails" で動いていますので、サーバーを起動すると log/development.log の owner は、コンテナ内から見ると "rails" ですが、ホスト上の（バインドマウントされている）ディレクトリで同ファイルを見ると、ホストのユーザ hiroaki になっています。

これは macOS だけの特徴とのことです。 Linux で様子を確かめたところ、コンテナでの owner とホストでの owner の uid が一致していないと、別ユーザのファイルを更新しようとしてしまうためにパーミッションのエラーになります。同一 uid なら、エラーにはなりません。こちらの挙動のほうが直感どおりです（不便ですが）。

名前付きボリュームにすることで、パーミッションの問題を回避します。 macOS の環境においては、ホスト側から直接ボリューム内を（ファイルシステムのように）見ることができなくなります。

File system sharing (osxfs)
https://docker-docs.uclv.cu/docker-for-mac/osxfs/#ownership

以下は、 Copilot さんによるサマリーです

This pull request makes improvements to the local development environment setup, focusing on Docker Compose configuration and developer documentation. The main changes include adding persistent Docker volumes for important Rails directories and enhancing the setup instructions in the documentation.

**Docker Compose enhancements:**

* Added persistent Docker volumes for `tmp`, `log`, and `storage` directories in the `web` service to ensure that temporary files, logs, and uploaded files are preserved across container restarts.
* Defined new Docker volumes (`tmp`, `log`, and `storage`) at the bottom of `compose.yml` for use by the Rails application.

**Documentation updates:**

* Updated `docs/DEVELOPMENT.md` to instruct developers to check and set required environment variables before running the application, and to run `bin/rails db:prepare` for initial database setup. Also clarified how to run Rails commands inside the container, with both English and Japanese explanations.