### PR TITLE
Cable 切断時にメッセージを表示するようにする

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,4 +69,17 @@ module ApplicationHelper
   def flash_global_storage
     content_tag(:div, '', id: 'flash-storage', style: 'display: none;')
   end
+
+  def exported_locale_messages
+    keys = %w[
+      cable_disconnected
+    ]
+    content_tag(:ul, id: 'exported-locale-messages', style: 'display: none;') do
+      safe_join(
+        keys.map do |key|
+          content_tag(:li, t("exports.#{key}"), data: { key: key })
+        end
+      )
+    end
+  end
 end

--- a/app/javascript/channels/messages_channel.js
+++ b/app/javascript/channels/messages_channel.js
@@ -1,4 +1,5 @@
 import consumer from "channels/consumer"
+import { appendMessageToStorage, renderFlashMessages, clearFlashMessages } from "flash_messages"
 
 consumer.subscriptions.create("MessagesChannel", {
   connected() {
@@ -8,7 +9,12 @@ consumer.subscriptions.create("MessagesChannel", {
 
   disconnected() {
     // Called when the subscription has been terminated by the server
-    console.log("MessagesChannel: disconnected")
+    console.log("MessagesChannel: disconnected");
+
+    const flashMessage = this.disconnectedMessage();
+    clearFlashMessages(flashMessage);
+    appendMessageToStorage(flashMessage, 'warning');
+    renderFlashMessages();
   },
 
   received(data) {
@@ -31,5 +37,11 @@ consumer.subscriptions.create("MessagesChannel", {
       const elem = messages.querySelector(`[data-message-id="${destroyed_message_id}"]`);
       if (elem) elem.remove();
     }
+  },
+
+  disconnectedMessage() {
+    const fallbackMessage = "Connection to the server has been lost. Please reload the page to reconnect";
+    const localeMessage = document.querySelector('#exported-locale-messages li[data-key="cable_disconnected"]');
+    return localeMessage ? localeMessage.textContent : fallbackMessage;
   }
 });

--- a/app/javascript/flash_messages.js
+++ b/app/javascript/flash_messages.js
@@ -230,13 +230,18 @@ function initializeFlashMessageSystem(debugFlag) {
   })();
 }
 
-/* フラッシュ・メッセージの表示をすべてクリアします。
+/* フラッシュ・メッセージの表示をクリアします。
+    message が指定されている場合は、そのメッセージを含んだフラッシュ・メッセージをクリアします。
+    message が省略された場合は全てが対象です。
   */
-function clearFlashMessages(){
-  const containers = document.querySelectorAll('[data-flash-message-container]');
-  containers.forEach(container => {
-    container.innerHTML = '';
-  });
+function clearFlashMessages(message) {
+  Array.from(document.querySelectorAll('[data-flash-message-container]'))
+    .filter(container => {
+      if (typeof message === 'undefined') return true;
+      const text = container.querySelector('.flash-message-text');
+      return text && text.textContent.trim() === message;
+    })
+    .forEach(container => { container.innerHTML = ''; });
 }
 
 // --- utility functions ---

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
     <%= flash_templates %>
     <%= flash_general_error_messages %>
     <%= flash_global_storage %>
+    <%= exported_locale_messages %>
 
     <header class="flex p-2 lg:px-6 text-xs text-center text-slate-400 items-center bg-gray-100">
       <div class="flex items-center">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,8 @@ en:
       taken: "has already been taken"
       too_long: "is too long (maximum is %{count} characters)"
       too_short: "is too short (minimum is %{count} characters)"
+  exports:
+    cable_disconnected: "Connection to the server has been lost. Please reload the page to reconnect."
   helpers:
     page_entries_info:
       more_pages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -95,6 +95,8 @@ ja:
       taken: "は既に使用されています"
       too_long: "は%{count}文字以内で入力してください"
       too_short: "は%{count}文字以上で入力してください"
+  exports:
+    cable_disconnected: "サーバーとの接続が切れました。再接続するには画面をリロードしてください。"
   helpers:
     page_entries_info:
       more_pages:


### PR DESCRIPTION
メッセージリスト画面で、なんらかの条件で Action Cable が切断されると、メッセージの投稿（他のクライアントから、自分のクライアントからいずれも）が、ブロードキャストされていても受け取られないので、メッセージリストが更新されません。

- disconnected を検知したら、その旨と、画面をリロードするように促すメッセージを表示するようにする
- ただしすでに同様のメッセージが表示されていた場合は表示しない

closes #59 