### PR TITLE
Turbo のプログレスバーが延々と伸び続ける問題を修正

### DIFF
--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -86,6 +86,7 @@
               link_to('&#x1F4BE;'.html_safe, rails_blob_path(att, disposition: 'attachment'),
                 class: 'tooltip-trigger inline-block ',
                 data: {
+                  turbo: false,
                   controller: 'tooltips',
                   tooltip: att.filename.to_s,
                 }


### PR DESCRIPTION
メッセージに添付されたファイルのダウンロードをクリックすると、 Trubo のデフォルトのプログレスバーの要素の width が、 100% を超えてもずっと成長し続けてしまう問題を修正します。

通常の A タグの、ファイル（ときに大きなサイズ）へのリンクなので、プリフェッチも働かない方がよいため、 turbo を false にしています。
