### PR TITLE
ActiveRecord暗号化キーの常時セットと2FA有効時の必須チェック

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,22 +25,18 @@ module Annabelle
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Two-factor authentication (2FA) and ActiveRecord encryption configuration
-    # When ENABLE_2FA is set, 2FA functionality becomes available in the application.
-    # 2FA requires ActiveRecord encryption to securely store OTP secrets, so all three
-    # encryption keys must be provided. If ENABLE_2FA is set but keys are missing,
-    # the application will fail fast with a clear error message.
-    if ENV['ENABLE_2FA'].present?
-      primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
-      deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
-      key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
+    # If all three AR encryption keys are present, always set them.
+    # If ENABLE_2FA is set, require all three keys and raise if missing.
+    primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
+    deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
+    key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
 
-      if primary_key.present? && deterministic_key.present? && key_derivation_salt.present?
-        config.active_record.encryption.primary_key = primary_key
-        config.active_record.encryption.deterministic_key = deterministic_key
-        config.active_record.encryption.key_derivation_salt = key_derivation_salt
-      else
-        raise '[Annabelle] ENABLE_2FA is set, but ActiveRecord encryption keys are missing or incomplete. You must set all three: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY, ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY, and ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT.'
-      end
+    if primary_key.present? && deterministic_key.present? && key_derivation_salt.present?
+      config.active_record.encryption.primary_key = primary_key
+      config.active_record.encryption.deterministic_key = deterministic_key
+      config.active_record.encryption.key_derivation_salt = key_derivation_salt
+    elsif ENV['ENABLE_2FA'].present?
+      raise '[Annabelle] ENABLE_2FA is set, but ActiveRecord encryption keys are missing or incomplete. You must set all three: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY, ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY, and ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT.'
     end
 
     # activerecord-session_store (gem) settings


### PR DESCRIPTION
2FA を有効にして運用したあとで 2FA を無効にしたとき、モデルの暗号化されたカラムが読み取れずに例外 `ActiveRecord::Encryption::Errors::Configuration: Missing Active Record encryption credential: active_record_encryption.primary_key (ActiveRecord::Encryption::Errors::Configuration)
` が発生してしまいます。

これは環境変数 ENABLE_2FA が指定されない時に、 AR の暗号化の設定もスキップしてしまっているためです。 AR の暗号化の設定が環境変数で値が提供されている場合は ENABLE_2FA の設定に関係なく、セットするべきです。

---
(GPT-4.1 による PR 作成）

このPRでは、ActiveRecord暗号化キー（PRIMARY_KEY, DETERMINISTIC_KEY, KEY_DERIVATION_SALT）がすべて揃っている場合は、2FAの有効・無効に関わらず常にセットするように修正しました。
また、2FA（ENABLE_2FA）が有効な場合は、暗号化キーが不足している場合に起動時に例外を投げて明確にエラーとするようにしています。

これにより、2FAを無効化した場合でも暗号化カラムの読み出しが可能となり、運用上の安全性・柔軟性が向上します。
