### PR TITLE
SQLite のメンテナンス用ツール

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -96,6 +96,15 @@ services:
       - "1080:1080"
       - "1025:1025"
 
+  sqlite:
+    # DBメンテナンス用サービス — 詳細は docker/sqlite/Dockerfile を参照
+    build:
+      context: ./docker/sqlite
+    volumes:
+      - storage:/rails/storage
+    working_dir: /rails/storage
+    tty: true
+
 volumes:
   bundle:
   tmp:

--- a/compose.yml
+++ b/compose.yml
@@ -113,7 +113,7 @@ services:
       - storage:/rails/storage
     working_dir: /rails/storage
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     entrypoint: ["sqlite_web"]
     command: ["-H", "0.0.0.0", "/rails/storage/development.sqlite3"]
     restart: "no"

--- a/compose.yml
+++ b/compose.yml
@@ -105,6 +105,19 @@ services:
     working_dir: /rails/storage
     tty: true
 
+  sqlite-web:
+    # SQLite をブラウザで操作するための Web UI (coleifer/sqlite-web)
+    image: coleifer/sqlite-web
+    platform: linux/amd64
+    volumes:
+      - storage:/rails/storage
+    working_dir: /rails/storage
+    ports:
+      - "8080:8080"
+    entrypoint: ["sqlite_web"]
+    command: ["-H", "0.0.0.0", "/rails/storage/development.sqlite3"]
+    restart: "no"
+
 volumes:
   bundle:
   tmp:

--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,12 @@
 #   # MailCatcher Web UI
 #   http://127.0.0.1:1080/
 #
+#   # SQLite Web UI
+#   http://127.0.0.1:8080/
+#
+#   # SQLite CLI
+#   $ docker compose run --rm sqlite sqlite3 /rails/storage/development.sqlite3
+#
 # development 環境用 compose.yml
 #
 # 使い方:
@@ -60,6 +66,12 @@
 #
 #   # MailCatcher の Web UI
 #   http://127.0.0.1:1080/
+#
+#   # SQLite Web UI
+#   http://127.0.0.1:8080/
+#
+#   # SQLite CLI
+#   $ docker compose run --rm sqlite sqlite3 /rails/storage/development.sqlite3
 #
 services:
   web:

--- a/compose.yml
+++ b/compose.yml
@@ -111,7 +111,6 @@ services:
     platform: linux/amd64
     volumes:
       - storage:/rails/storage
-    working_dir: /rails/storage
     ports:
       - "127.0.0.1:8080:8080"
     entrypoint: ["sqlite_web"]

--- a/docker/sqlite/Dockerfile
+++ b/docker/sqlite/Dockerfile
@@ -1,0 +1,7 @@
+# この Dockerfile は、Docker ボリューム (storage) に保存された SQLite データベース
+# ファイルにコンテナ内からアクセス・操作するためのイメージを作成します。
+# 例: `docker compose run --rm sqlite sqlite3 /rails/storage/development.sqlite3`
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y sqlite3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+WORKDIR /data
+ENTRYPOINT ["sqlite3"]


### PR DESCRIPTION
SQLite のデータベースのファイルが Docker ボリュームに入っており、そのままではホストマシンから参照できないため、専用のコンテナを用意します。

- コマンドラインから sqlite3 コマンドを実行するコンテナ
- Web UI を起動するコンテナ
