### PR TITLE
ActiveStorage の孤立ファイルを定期的にクリーンアップする rake タスクの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,34 @@ See [/docs/DEPLOY.md](/docs/DEPLOY.md)
 
 ## Operation / 運用について
 
+### Session information Cleanup / セッション情報のクリーンアップ
+
 Session information is stored in the database using [activerecord-session_store](https://github.com/rails/activerecord-session_store). Since old session records will remain unless cleaned up, please make sure to delete them periodically. A rake task is provided for this purpose, which deletes sessions older than 30 days by default. To specify a different threshold, set the number of days via the SESSION_DAYS_TRIM_THRESHOLD environment variable before running the task.
 
 セッション情報は [activerecord-session_store](https://github.com/rails/activerecord-session_store) を用いてデータベースに保存しています。古いセッションのレコードが残るため、定期的に削除してください。削除のための rake タスクがあり、実行すると、デフォルトでは 30日を経過したものが削除されます。この日数を指定したい場合は環境変数 `SESSION_DAYS_TRIM_THRESHOLD` に日数を指定して実行してください。
 
 ```
 $ SESSION_DAYS_TRIM_THRESHOLD=30 bin/rails db:sessions:trim
+```
+
+### Active Storage Cleanup / Active Storage のクリーンアップ
+
+ A rake task is available to safely clean up orphaned Active Storage blobs (for example, when a message is deleted but its attachments are not physically removed).
+
+Active Storage の孤立ファイル（例：メッセージを削除しても添付が物理削除されない場合）を安全にクリーンアップするための rake タスクを用意しています。
+
+```bash
+# Dry run (no deletion)
+# 確認のみ（削除はしません）
+$ bin/rake active_storage:cleanup
+
+# Execute deletion (enqueue purge_later)
+# 削除を実行（purge_later をエンキュー）
+$ bin/rake active_storage:cleanup FORCE=true
+
+# Target orphaned blobs older than 7 days (default: 2)
+# 7日より古い孤立ファイルを削除対象（デフォルト2日）
+$ bin/rake active_storage:cleanup FORCE=true DAYS_OLD=7
 ```
 
 ## License / ライセンス

--- a/app/services/active_storage_cleanup_service.rb
+++ b/app/services/active_storage_cleanup_service.rb
@@ -1,3 +1,11 @@
+# Service to safely purge unattached Active Storage blobs.
+#
+# It finds blobs that are not attached to any record and are older than a specified
+# number of days (default: 2), then purges them.
+#
+# Usage:
+#   ActiveStorageCleanupService.new(days_old: 7, dry_run: false).call
+#
 class ActiveStorageCleanupService
   def initialize(days_old: 2, dry_run: true, logger: Logger.new($stdout))
     @days_old = days_old

--- a/app/services/active_storage_cleanup_service.rb
+++ b/app/services/active_storage_cleanup_service.rb
@@ -44,12 +44,20 @@ class ActiveStorageCleanupService
     @logger.info "Purging unattached blobs created before #{cutoff_period}..."
 
     count = 0
+    progress_printed = false
+
     blobs.find_each do |blob|
       blob.purge_later
       count += 1
-      @logger.print '.' if count % 50 == 0
+      if count % 50 == 0
+        @logger.print '.'
+        progress_printed = true
+      end
     end
 
-    @logger.info "\nDone. #{count} blobs have been enqueued for deletion."
+    # ドットが出力されていて、かつ最後の出力で行が変わっていない場合は改行を入れる
+    @logger.print "\n" if progress_printed
+
+    @logger.info "Done. #{count} blobs have been enqueued for deletion."
   end
 end

--- a/app/services/active_storage_cleanup_service.rb
+++ b/app/services/active_storage_cleanup_service.rb
@@ -34,19 +34,18 @@ class ActiveStorageCleanupService
     # nil の場合はデフォルト値 2 を採用する
     return 2 if value.nil?
 
-    # 数値の場合
-    if value.is_a?(Numeric)
-      raise InvalidDaysOldError, 'days_old must be a positive number' unless value > 0
+    # 数値の場合（整数のみ許可）
+    if value.is_a?(Integer)
+      raise InvalidDaysOldError, 'days_old must be a positive integer' unless value > 0
       return value
     end
 
-    # 文字列の場合（正の整数または小数を許容）
-    if value.is_a?(String) && value =~ /\A[1-9]\d*(\.\d+)?\z/
-      return value.to_f if value.include?('.')
+    # 文字列の場合（正の整数のみ許可）
+    if value.is_a?(String) && value =~ /\A[1-9]\d*\z/
       return value.to_i
     end
 
-    raise InvalidDaysOldError, "days_old must be a positive number, got: #{value.inspect}"
+    raise InvalidDaysOldError, "days_old must be a positive integer, got: #{value.inspect}"
   end
 
   def perform_dry_run(blobs, cutoff_period)

--- a/app/services/active_storage_cleanup_service.rb
+++ b/app/services/active_storage_cleanup_service.rb
@@ -1,0 +1,55 @@
+class ActiveStorageCleanupService
+  def initialize(days_old: 2, dry_run: true, logger: Logger.new($stdout))
+    @days_old = days_old
+    @dry_run = dry_run
+    @logger = logger
+  end
+
+  def call
+    cutoff_period = @days_old.days.ago
+    unattached_blobs = ActiveStorage::Blob.unattached.where('active_storage_blobs.created_at <= ?', cutoff_period)
+
+    if @dry_run
+      perform_dry_run(unattached_blobs, cutoff_period)
+    else
+      perform_cleanup(unattached_blobs, cutoff_period)
+    end
+  end
+
+  private
+
+  def perform_dry_run(blobs, cutoff_period)
+    @logger.info '=== DRY RUN MODE ==='
+    @logger.info "Searching for unattached blobs created before #{cutoff_period}..."
+    @logger.info 'The following blobs would be purged:'
+
+    count = 0
+    total_size = 0
+
+    blobs.find_each do |blob|
+      @logger.info "ID: #{blob.id} | Filename: #{blob.filename} | Created: #{blob.created_at} | Size: #{ActiveSupport::NumberHelper.number_to_human_size(blob.byte_size)}"
+      count += 1
+      total_size += blob.byte_size
+    end
+
+    @logger.info '--------------------'
+    @logger.info "Total blobs found: #{count}"
+    @logger.info "Total size: #{ActiveSupport::NumberHelper.number_to_human_size(total_size)}"
+    @logger.info ''
+    @logger.info 'To actually purge these files, run with dry_run: false'
+  end
+
+  def perform_cleanup(blobs, cutoff_period)
+    @logger.info '=== EXECUTE MODE ==='
+    @logger.info "Purging unattached blobs created before #{cutoff_period}..."
+
+    count = 0
+    blobs.find_each do |blob|
+      blob.purge_later
+      count += 1
+      @logger.print '.' if count % 50 == 0
+    end
+
+    @logger.info "\nDone. #{count} blobs have been enqueued for deletion."
+  end
+end

--- a/app/services/active_storage_cleanup_service.rb
+++ b/app/services/active_storage_cleanup_service.rb
@@ -76,11 +76,13 @@ class ActiveStorageCleanupService
     @logger.info "Purging unattached blobs created before #{cutoff_period}..."
 
     count = 0
+    total_size = 0
     progress_printed = false
 
     blobs.find_each do |blob|
       blob.purge_later
       count += 1
+      total_size += blob.byte_size
       if count % 50 == 0
         # Intentionally use << (no newline) to show progress dots on the same line every 50 blobs.
         @logger << '.'
@@ -93,6 +95,6 @@ class ActiveStorageCleanupService
 
     @logger.info "Done. #{count} blobs have been enqueued for deletion."
 
-    { count: count, dry_run: false }
+    { count: count, total_size: total_size, dry_run: false }
   end
 end

--- a/app/services/active_storage_cleanup_service.rb
+++ b/app/services/active_storage_cleanup_service.rb
@@ -13,6 +13,8 @@ class ActiveStorageCleanupService
     @logger = logger
   end
 
+  # Returns a Hash with execution results (count, total_size, dry_run).
+  # Note: The return structure may be revisited in the future as requirements evolve.
   def call
     cutoff_period = @days_old.days.ago
     unattached_blobs = ActiveStorage::Blob.unattached.where('active_storage_blobs.created_at <= ?', cutoff_period)
@@ -45,6 +47,8 @@ class ActiveStorageCleanupService
     @logger.info "Total size: #{ActiveSupport::NumberHelper.number_to_human_size(total_size)}"
     @logger.info ''
     @logger.info 'To actually purge these files, run with dry_run: false'
+
+    { count: count, total_size: total_size, dry_run: true }
   end
 
   def perform_cleanup(blobs, cutoff_period)
@@ -67,5 +71,7 @@ class ActiveStorageCleanupService
     @logger.print "\n" if progress_printed
 
     @logger.info "Done. #{count} blobs have been enqueued for deletion."
+
+    { count: count, dry_run: false }
   end
 end

--- a/app/services/active_storage_cleanup_service.rb
+++ b/app/services/active_storage_cleanup_service.rb
@@ -83,13 +83,14 @@ class ActiveStorageCleanupService
       blob.purge_later
       count += 1
       if count % 50 == 0
-        @logger.print '.'
+        # Intentionally use << (no newline) to show progress dots on the same line every 50 blobs.
+        @logger << '.'
         progress_printed = true
       end
     end
 
     # ドットが出力されていて、かつ最後の出力で行が変わっていない場合は改行を入れる
-    @logger.print "\n" if progress_printed
+    @logger << "\n" if progress_printed
 
     @logger.info "Done. #{count} blobs have been enqueued for deletion."
 

--- a/lib/tasks/active_storage_cleanup.rake
+++ b/lib/tasks/active_storage_cleanup.rake
@@ -1,0 +1,63 @@
+# ActiveStorage の孤立ファイル（どのモデルにもアタッチされていない Blob）を削除するタスク
+#
+# 使い方:
+#   # 確認（Dry Run）: 削除対象のリストと合計サイズを表示
+#   rake active_storage:cleanup
+#
+#   # 実行（削除）: 実際に削除を実行（purge_later）
+#   rake active_storage:cleanup FORCE=true
+#
+#   # オプション:
+#   #   DAYS_OLD: 作成から指定した日数以上経過したファイルを対象とする（デフォルト: 2）
+#   rake active_storage:cleanup DAYS_OLD=7
+
+namespace :active_storage do
+  desc "Purges unattached Active Storage blobs. Default is dry-run. Use FORCE=true to execute."
+  task cleanup: :environment do
+    # 安全のため、作成から一定期間経過したものを対象とする（デフォルト2日）
+    # アップロード直後のファイルなどを誤って削除しないための猶予期間
+    days_old = ENV.fetch("DAYS_OLD", 2).to_i
+    cutoff_period = days_old.days.ago
+
+    # 未アタッチかつ古いBlobを検索
+    # unattached スコープは ActiveStorage::Blob で定義されている
+    unattached_blobs = ActiveStorage::Blob.unattached.where("active_storage_blobs.created_at <= ?", cutoff_period)
+
+    # FORCE環境変数が "true" でない限り、Dry Run モードとする
+    is_dry_run = ENV["FORCE"] != "true"
+
+    if is_dry_run
+      puts "=== DRY RUN MODE ==="
+      puts "Searching for unattached blobs created before #{cutoff_period}..."
+      puts "The following blobs would be purged:"
+
+      count = 0
+      total_size = 0
+
+      unattached_blobs.find_each do |blob|
+        puts "ID: #{blob.id} | Filename: #{blob.filename} | Created: #{blob.created_at} | Size: #{ActiveSupport::NumberHelper.number_to_human_size(blob.byte_size)}"
+        count += 1
+        total_size += blob.byte_size
+      end
+
+      puts "--------------------"
+      puts "Total blobs found: #{count}"
+      puts "Total size: #{ActiveSupport::NumberHelper.number_to_human_size(total_size)}"
+      puts ""
+      puts "To actually purge these files, run the task with FORCE=true:"
+      puts "  rake active_storage:cleanup FORCE=true"
+    else
+      puts "=== EXECUTE MODE ==="
+      puts "Purging unattached blobs created before #{cutoff_period}..."
+
+      count = 0
+      unattached_blobs.find_each do |blob|
+        blob.purge_later
+        count += 1
+        print "." if count % 50 == 0
+      end
+
+      puts "\nDone. #{count} blobs have been enqueued for deletion."
+    end
+  end
+end

--- a/lib/tasks/active_storage_cleanup.rake
+++ b/lib/tasks/active_storage_cleanup.rake
@@ -12,52 +12,15 @@
 #   rake active_storage:cleanup DAYS_OLD=7
 
 namespace :active_storage do
-  desc "Purges unattached Active Storage blobs. Default is dry-run. Use FORCE=true to execute."
+  desc 'Purges unattached Active Storage blobs. Default is dry-run. Use FORCE=true to execute.'
   task cleanup: :environment do
     # 安全のため、作成から一定期間経過したものを対象とする（デフォルト2日）
     # アップロード直後のファイルなどを誤って削除しないための猶予期間
-    days_old = ENV.fetch("DAYS_OLD", 2).to_i
-    cutoff_period = days_old.days.ago
-
-    # 未アタッチかつ古いBlobを検索
-    # unattached スコープは ActiveStorage::Blob で定義されている
-    unattached_blobs = ActiveStorage::Blob.unattached.where("active_storage_blobs.created_at <= ?", cutoff_period)
+    days_old = ENV.fetch('DAYS_OLD', 2).to_i
 
     # FORCE環境変数が "true" でない限り、Dry Run モードとする
-    is_dry_run = ENV["FORCE"] != "true"
+    is_dry_run = ENV['FORCE'] != 'true'
 
-    if is_dry_run
-      puts "=== DRY RUN MODE ==="
-      puts "Searching for unattached blobs created before #{cutoff_period}..."
-      puts "The following blobs would be purged:"
-
-      count = 0
-      total_size = 0
-
-      unattached_blobs.find_each do |blob|
-        puts "ID: #{blob.id} | Filename: #{blob.filename} | Created: #{blob.created_at} | Size: #{ActiveSupport::NumberHelper.number_to_human_size(blob.byte_size)}"
-        count += 1
-        total_size += blob.byte_size
-      end
-
-      puts "--------------------"
-      puts "Total blobs found: #{count}"
-      puts "Total size: #{ActiveSupport::NumberHelper.number_to_human_size(total_size)}"
-      puts ""
-      puts "To actually purge these files, run the task with FORCE=true:"
-      puts "  rake active_storage:cleanup FORCE=true"
-    else
-      puts "=== EXECUTE MODE ==="
-      puts "Purging unattached blobs created before #{cutoff_period}..."
-
-      count = 0
-      unattached_blobs.find_each do |blob|
-        blob.purge_later
-        count += 1
-        print "." if count % 50 == 0
-      end
-
-      puts "\nDone. #{count} blobs have been enqueued for deletion."
-    end
+    ActiveStorageCleanupService.new(days_old: days_old, dry_run: is_dry_run).call
   end
 end

--- a/lib/tasks/active_storage_cleanup.rake
+++ b/lib/tasks/active_storage_cleanup.rake
@@ -19,8 +19,8 @@ namespace :active_storage do
     days_old = ENV.fetch('DAYS_OLD', 2).to_i
 
     # FORCE環境変数が "true" でない限り、Dry Run モードとする
-    is_dry_run = ENV['FORCE'] != 'true'
+    dry_run = ENV['FORCE'] != 'true'
 
-    ActiveStorageCleanupService.new(days_old: days_old, dry_run: is_dry_run).call
+    ActiveStorageCleanupService.new(days_old: days_old, dry_run: dry_run).call
   end
 end

--- a/lib/tasks/active_storage_cleanup.rake
+++ b/lib/tasks/active_storage_cleanup.rake
@@ -16,11 +16,15 @@ namespace :active_storage do
   task cleanup: :environment do
     # 安全のため、作成から一定期間経過したものを対象とする（デフォルト2日）
     # アップロード直後のファイルなどを誤って削除しないための猶予期間
-    days_old = ENV.fetch('DAYS_OLD', 2).to_i
+    days_old = ENV['DAYS_OLD']
 
     # FORCE環境変数が "true" でない限り、Dry Run モードとする
     dry_run = ENV['FORCE'] != 'true'
 
-    ActiveStorageCleanupService.new(days_old: days_old, dry_run: dry_run).call
+    begin
+      ActiveStorageCleanupService.new(days_old: days_old, dry_run: dry_run).call
+    rescue ActiveStorageCleanupService::InvalidDaysOldError => e
+      abort "Error: #{e.message}"
+    end
   end
 end

--- a/spec/services/active_storage_cleanup_service_spec.rb
+++ b/spec/services/active_storage_cleanup_service_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
   end
 
   describe '#call' do
+    # テスト間の干渉を防ぐため、実行前にジョブキューをクリアする
+    before do
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    end
+
     context 'when dry_run is true' do
       let(:dry_run) { true }
 
@@ -69,11 +74,6 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
 
     context 'when dry_run is false' do
       let(:dry_run) { false }
-
-      # テスト間の干渉を防ぐため、ジョブキューをクリアする
-      before do
-        ActiveJob::Base.queue_adapter.enqueued_jobs.clear
-      end
 
       # エンキューされたジョブのGlobalIDリストを取得するヘルパー
       let(:enqueued_gids) do

--- a/spec/services/active_storage_cleanup_service_spec.rb
+++ b/spec/services/active_storage_cleanup_service_spec.rb
@@ -139,6 +139,32 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
           expect { service.call }.to output(/=== DRY RUN MODE ===/).to_stdout
         end
       end
+
+      context 'when invalid days_old is provided' do
+        it 'raises InvalidDaysOldError for negative number' do
+          expect {
+            described_class.new(days_old: -1, dry_run: dry_run, logger: logger)
+          }.to raise_error(ActiveStorageCleanupService::InvalidDaysOldError)
+        end
+
+        it 'raises InvalidDaysOldError for zero' do
+          expect {
+            described_class.new(days_old: 0, dry_run: dry_run, logger: logger)
+          }.to raise_error(ActiveStorageCleanupService::InvalidDaysOldError)
+        end
+
+        it 'raises InvalidDaysOldError for invalid string' do
+          expect {
+            described_class.new(days_old: "invalid", dry_run: dry_run, logger: logger)
+          }.to raise_error(ActiveStorageCleanupService::InvalidDaysOldError)
+        end
+
+        it 'accepts valid string number' do
+          expect {
+            described_class.new(days_old: "5", dry_run: dry_run, logger: logger)
+          }.not_to raise_error
+        end
+      end
     end
   end
 end

--- a/spec/services/active_storage_cleanup_service_spec.rb
+++ b/spec/services/active_storage_cleanup_service_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
     context 'when dry_run is false' do
       let(:dry_run) { false }
 
+      # テスト間の干渉を防ぐため、ジョブキューをクリアする
+      before do
+        ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+      end
+
       # エンキューされたジョブのGlobalIDリストを取得するヘルパー
       let(:enqueued_gids) do
         ActiveJob::Base.queue_adapter.enqueued_jobs.map do |job|

--- a/spec/services/active_storage_cleanup_service_spec.rb
+++ b/spec/services/active_storage_cleanup_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
       io: StringIO.new("new content"),
       filename: "new.txt",
       content_type: "text/plain"
-    ).tap { |blob| blob.update(created_at: 1.day.ago) }
+    ).tap { |blob| blob.update(created_at: 1.day.ago - 1.second) }
   end
 
   let!(:attached_blob) do
@@ -145,7 +145,7 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
       end
 
       context 'when custom days_old is provided' do
-        # 1日前より古いものを対象にする -> 1日前の new_unattached_blob も対象になるはず
+        # 1日前より「厳密に」古いものを対象にする -> 1日前-1秒の new_unattached_blob も対象になる
         let(:service) { described_class.new(days_old: 1, dry_run: dry_run, logger: logger) }
 
         it 'includes blobs older than the custom days' do

--- a/spec/services/active_storage_cleanup_service_spec.rb
+++ b/spec/services/active_storage_cleanup_service_spec.rb
@@ -46,9 +46,23 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
         }.not_to have_enqueued_job(ActiveStorage::PurgeJob)
       end
 
-      it 'logs the blobs that would be purged' do
+      it 'logs the blobs that would be purged correctly' do
+        # Dry Runモードの開始ログ
         expect(logger).to receive(:info).with(/DRY RUN MODE/)
+
+        # 削除対象のBlobが表示されること
         expect(logger).to receive(:info).with(/ID: #{old_unattached_blob.id}/)
+
+        # 削除対象外のBlobが表示されないこと（重要）
+        expect(logger).not_to receive(:info).with(/ID: #{new_unattached_blob.id}/)
+        expect(logger).not_to receive(:info).with(/ID: #{attached_blob.id}/)
+
+        # 集計結果が正しいこと（1件のみ）
+        expect(logger).to receive(:info).with(/Total blobs found: 1/)
+        
+        # 合計サイズの表示（"old content" は 11 bytes）
+        expect(logger).to receive(:info).with(/Total size: 11 Bytes/)
+
         service.call
       end
     end

--- a/spec/services/active_storage_cleanup_service_spec.rb
+++ b/spec/services/active_storage_cleanup_service_spec.rb
@@ -104,6 +104,11 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
         service.call
       end
 
+      it 'returns correct execution stats including total_size' do
+        result = service.call
+        expect(result).to eq({ count: 1, total_size: 11, dry_run: false })
+      end
+
       it 'prints progress dots for large number of blobs' do
         # N+1検知を一時的に無効化（テストデータ作成時のINSERT連打を許容）
         Prosopite.pause do

--- a/spec/services/active_storage_cleanup_service_spec.rb
+++ b/spec/services/active_storage_cleanup_service_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
       end
 
       context 'when custom days_old is provided' do
-        # 0.5日前（12時間前）より古いものを対象にする -> 1日前の new_unattached_blob も対象になるはず
-        let(:service) { described_class.new(days_old: 0.5, dry_run: dry_run, logger: logger) }
+        # 1日前より古いものを対象にする -> 1日前の new_unattached_blob も対象になるはず
+        let(:service) { described_class.new(days_old: 1, dry_run: dry_run, logger: logger) }
 
         it 'includes blobs older than the custom days' do
           expect(logger).to receive(:info).with(/ID: #{new_unattached_blob.id}/)
@@ -171,6 +171,12 @@ RSpec.describe ActiveStorageCleanupService, type: :service do
         it 'raises InvalidDaysOldError for zero' do
           expect {
             described_class.new(days_old: 0, dry_run: dry_run, logger: logger)
+          }.to raise_error(ActiveStorageCleanupService::InvalidDaysOldError)
+        end
+
+        it 'raises InvalidDaysOldError for float number' do
+          expect {
+            described_class.new(days_old: 1.5, dry_run: dry_run, logger: logger)
           }.to raise_error(ActiveStorageCleanupService::InvalidDaysOldError)
         end
 


### PR DESCRIPTION
 #102 の実装です。タイトルのとおり、ActiveStorage の孤立ファイルを定期的にクリーンアップする rake タスクの追加します。
なお、コードは Gemini 3 Pro (Preview) によるものです。

---

This pull request introduces a safe and configurable cleanup mechanism for unattached Active Storage blobs, including a new service class, a Rake task for easy execution, and comprehensive RSpec tests. The changes ensure that only blobs older than a specified number of days are considered for deletion, and provide a dry-run mode for verification before actual purging.

**Active Storage cleanup feature:**

* Added `ActiveStorageCleanupService` to encapsulate logic for finding and purging unattached blobs older than a configurable number of days, with support for dry-run and logging.
* Introduced a Rake task (`lib/tasks/active_storage_cleanup.rake`) to run the cleanup service from the command line, supporting options for dry-run, force deletion, and custom age thresholds.

**Testing and reliability:**

* Added RSpec tests for `ActiveStorageCleanupService` to verify both dry-run and actual purge modes, ensuring only old, unattached blobs are targeted and attached or recent blobs are not affected.