### PR TITLE
Add tests for ImageMetadata::Stripper

### DIFF
--- a/spec/services/image_metadata/stripper_spec.rb
+++ b/spec/services/image_metadata/stripper_spec.rb
@@ -201,6 +201,34 @@ RSpec.describe ImageMetadata::Stripper do
         expect(result).to eq(attachable)
       end
     end
+
+    describe '.process_with_minimagick' do
+      it 'returns a tempfile containing stripped blob data' do
+        mini_magick_module = Module.new
+        image_class = Class.new do
+          def self.read(_data); end
+        end
+        mini_magick_module.const_set(:Image, image_class)
+        stub_const('MiniMagick', mini_magick_module)
+
+        image = double('mini_magick_image')
+        allow(image).to receive(:strip)
+        allow(image).to receive(:to_blob).and_return('stripped-binary')
+        allow(MiniMagick::Image).to receive(:read).with('raw-image-data').and_return(image)
+
+        tempfile = described_class.send(:process_with_minimagick, 'raw-image-data', 'jpg')
+
+        expect(tempfile).to be_a(Tempfile)
+        expect(image).to have_received(:strip)
+        expect(image).to have_received(:to_blob)
+
+        tempfile.rewind
+        expect(tempfile.read).to eq('stripped-binary')
+        expect(File.extname(tempfile.path)).to eq('.jpg')
+      ensure
+        tempfile.close! if tempfile
+      end
+    end
     end
   end
 end

--- a/spec/services/image_metadata/stripper_spec.rb
+++ b/spec/services/image_metadata/stripper_spec.rb
@@ -3,246 +3,246 @@ require 'rails_helper'
 RSpec.describe ImageMetadata::Stripper do
   context 'as a service', type: :service do
     describe '.strip_and_upload' do
-    let(:user) { create(:user) }
+      let(:user) { create(:user) }
 
-    it 'uploads a large in-memory file without raising and persists metadata' do
-      # Create a temporary large binary file at test runtime (5 MB)
-      size_mb = 5
-      tmp = Tempfile.new(['large_test', '.jpg'])
-      tmp.binmode
-      size_mb.times { tmp.write("\0" * 1_048_576) } # write 1MB chunks
-      tmp.rewind
+      it 'uploads a large in-memory file without raising and persists metadata' do
+        # Create a temporary large binary file at test runtime (5 MB)
+        size_mb = 5
+        tmp = Tempfile.new(['large_test', '.jpg'])
+        tmp.binmode
+        size_mb.times { tmp.write("\0" * 1_048_576) } # write 1MB chunks
+        tmp.rewind
 
-      metadata = { 'upload_settings' => { 'strip_metadata' => true, 'allow_location_public' => false } }
+        metadata = { 'upload_settings' => { 'strip_metadata' => true, 'allow_location_public' => false } }
 
-      attachable = { io: tmp, filename: 'large_test.jpg', content_type: 'image/jpeg' }
+        attachable = { io: tmp, filename: 'large_test.jpg', content_type: 'image/jpeg' }
 
-      blob = nil
-      expect {
-        blob = ImageMetadata::Stripper.strip_and_upload(attachable, metadata: metadata)
-      }.not_to raise_error
+        blob = nil
+        expect {
+          blob = ImageMetadata::Stripper.strip_and_upload(attachable, metadata: metadata)
+        }.not_to raise_error
 
-      expect(blob).to be_present
-      expect(blob.byte_size).to eq(size_mb * 1_048_576)
-      expect(blob.metadata['upload_settings']).to eq(metadata['upload_settings'])
+        expect(blob).to be_present
+        expect(blob.byte_size).to eq(size_mb * 1_048_576)
+        expect(blob.metadata['upload_settings']).to eq(metadata['upload_settings'])
 
-      # Clean up uploaded blob and tempfile
-      blob.purge if blob
-      tmp.close!
-    end
-
-    it 'accepts an existing blob and creates a new stripped blob' do
-      # Create a small source blob to simulate existing upload
-      source_blob = ActiveStorage::Blob.create_and_upload!(io: File.open(Rails.root.join('spec/fixtures/files/test_image.jpg')), filename: 'src.jpg', content_type: 'image/jpeg')
-
-      metadata = { 'upload_settings' => { 'strip_metadata' => true } }
-      new_blob = ImageMetadata::Stripper.strip_and_upload(source_blob, metadata: metadata)
-
-      expect(new_blob).to be_present
-      expect(new_blob.id).not_to eq(source_blob.id)
-      expect(new_blob.metadata['upload_settings']).to eq(metadata['upload_settings'])
-
-      # cleanup
-      new_blob.purge if new_blob
-      source_blob.purge if source_blob
-    end
-
-    context 'error handling' do
-      it 'logs a warning and returns nil if an exception occurs' do
-        attachable = { io: StringIO.new('test'), filename: 'test.jpg', content_type: 'image/jpeg' }
-        allow(described_class).to receive(:strip).and_raise(StandardError, 'Simulated failure')
-
-        expect(Rails.logger).to receive(:warn).with(/strip_and_upload failed: StandardError: Simulated failure/)
-        expect(described_class.strip_and_upload(attachable)).to be_nil
+        # Clean up uploaded blob and tempfile
+        blob.purge if blob
+        tmp.close!
       end
 
-      it 'returns nil if stripping fails to produce a valid IO' do
-        attachable = { io: StringIO.new('test'), filename: 'test.jpg', content_type: 'image/jpeg' }
-        # Simulate strip returning something invalid or nil so it falls through to the final nil return
-        allow(described_class).to receive(:strip).and_return(nil)
+      it 'accepts an existing blob and creates a new stripped blob' do
+        # Create a small source blob to simulate existing upload
+        source_blob = ActiveStorage::Blob.create_and_upload!(io: File.open(Rails.root.join('spec/fixtures/files/test_image.jpg')), filename: 'src.jpg', content_type: 'image/jpeg')
 
-        expect(described_class.strip_and_upload(attachable)).to be_nil
-      end
-    end
-  end
+        metadata = { 'upload_settings' => { 'strip_metadata' => true } }
+        new_blob = ImageMetadata::Stripper.strip_and_upload(source_blob, metadata: metadata)
 
-  describe '.strip' do
-    let(:fixture_path) { Rails.root.join('spec/fixtures/files/image_with_gps.jpg') }
+        expect(new_blob).to be_present
+        expect(new_blob.id).not_to eq(source_blob.id)
+        expect(new_blob.metadata['upload_settings']).to eq(metadata['upload_settings'])
 
-    context 'with a valid image attachable' do
-      let(:io) { File.open(fixture_path, 'rb') }
-      let(:attachable) do
-        {
-          io: io,
-          filename: 'image_with_gps.jpg',
-          content_type: 'image/jpeg'
-        }
+        # cleanup
+        new_blob.purge if new_blob
+        source_blob.purge if source_blob
       end
 
-      after do
-        io.close
-      end
+      context 'error handling' do
+        it 'logs a warning and returns nil if an exception occurs' do
+          attachable = { io: StringIO.new('test'), filename: 'test.jpg', content_type: 'image/jpeg' }
+          allow(described_class).to receive(:strip).and_raise(StandardError, 'Simulated failure')
 
-      it 'returns a new attachable whose IO has no EXIF metadata' do
-        result = nil
-        result = described_class.strip(attachable)
-
-        expect(result[:io]).not_to eq(attachable[:io])
-        expect(result[:filename]).to eq('image_with_gps.jpg')
-
-        # 特定の画像処理ライブラリ（MiniMagick や Vips）に依存せず、
-        # バイナリレベルで EXIF ヘッダの有無を確認する
-        result[:io].rewind
-        stripped_data = result[:io].read
-
-        # 一般的な JPEG の Exif ヘッダシグネチャが含まれていないことを確認
-        # "Exif\0\0" は JPEG APP1 マーカー内の Exif 識別子です
-        expect(stripped_data).not_to include("Exif\0\0")
-
-        # 念のため、元のファイルには含まれていたことも確認（テストデータの妥当性保証）
-        attachable[:io].rewind
-        original_data = attachable[:io].read
-        expect(original_data).to include("Exif\0\0")
-      ensure
-        result[:io].close! if result&.dig(:io).is_a?(Tempfile)
-      end
-    end
-
-    context 'when attachable is missing IO' do
-      it 'returns the original attachable unchanged' do
-        attachable = { filename: 'no-io.jpg', content_type: 'image/jpeg' }
-        expect(described_class.strip(attachable)).to eq(attachable)
-      end
-    end
-
-    context 'when processing fails' do
-      it 'falls back to the original IO' do
-        io = StringIO.new('not-an-image')
-        attachable = { io: io, filename: 'bad', content_type: 'image/jpeg' }
-
-        allow(described_class).to receive(:process_with_vips).and_raise(StandardError)
-        allow(described_class).to receive(:process_with_image_processing_minimagick).and_return(nil)
-        allow(described_class).to receive(:process_with_minimagick).and_return(nil)
-
-        result = described_class.strip(attachable)
-        expect(result).to eq(attachable)
-        expect(io.pos).to eq(0)
-      end
-    end
-
-    context 'when all processors return nil' do
-      it 'rewinds the original io and returns attachable unchanged' do
-        io = StringIO.new('image-data')
-        io.read # advance pointer to ensure method rewinds
-        attachable = { io: io, filename: 'still-original.jpg', content_type: 'image/jpeg' }
-
-        allow(described_class).to receive(:process_with_vips).and_return(nil)
-        allow(described_class).to receive(:process_with_image_processing_minimagick).and_return(nil)
-        allow(described_class).to receive(:process_with_minimagick).and_return(nil)
-
-        result = described_class.strip(attachable)
-
-        expect(result).to eq(attachable)
-        expect(io.pos).to eq(0)
-      end
-    end
-
-    context 'when filename lacks extension' do
-      it 'infers the extension from content type' do
-        io = StringIO.new('binary-image-data')
-        attachable = { io: io, filename: 'upload', content_type: 'image/png' }
-        captured_ext = nil
-
-        allow(described_class).to receive(:process_with_vips).and_return(nil)
-        allow(described_class).to receive(:process_with_image_processing_minimagick) do |data, ext|
-          captured_ext = ext
-          nil
+          expect(Rails.logger).to receive(:warn).with(/strip_and_upload failed: StandardError: Simulated failure/)
+          expect(described_class.strip_and_upload(attachable)).to be_nil
         end
-        allow(described_class).to receive(:process_with_minimagick).and_return(nil)
 
-        described_class.strip(attachable)
+        it 'returns nil if stripping fails to produce a valid IO' do
+          attachable = { io: StringIO.new('test'), filename: 'test.jpg', content_type: 'image/jpeg' }
+          # Simulate strip returning something invalid or nil so it falls through to the final nil return
+          allow(described_class).to receive(:strip).and_return(nil)
 
-        expect(captured_ext).to eq('png')
-      end
-    end
-
-    context 'when neither filename nor content type provide image extension' do
-      it 'falls back to jpg' do
-        io = StringIO.new('binary-data')
-        attachable = { io: io, filename: 'upload', content_type: 'application/octet-stream' }
-        captured_ext = nil
-
-        allow(described_class).to receive(:process_with_vips).and_return(nil)
-        allow(described_class).to receive(:process_with_image_processing_minimagick) do |_, ext|
-          captured_ext = ext
-          nil
+          expect(described_class.strip_and_upload(attachable)).to be_nil
         end
-        allow(described_class).to receive(:process_with_minimagick).and_return(nil)
-
-        described_class.strip(attachable)
-
-        expect(captured_ext).to eq('jpg')
       end
     end
 
-    context 'when MiniMagick backend raises' do
-      it 'logs the failure and returns the original attachable' do
-        io = StringIO.new('image-data')
-        attachable = { io: io, filename: 'sample.jpg', content_type: 'image/jpeg' }
+    describe '.strip' do
+      let(:fixture_path) { Rails.root.join('spec/fixtures/files/image_with_gps.jpg') }
 
-        allow(ImageMetadata::Stripper).to receive(:process_with_vips).and_return(nil)
-        allow(ImageMetadata::Stripper).to receive(:process_with_image_processing_minimagick).and_return(nil)
-        allow(MiniMagick::Image).to receive(:read).and_raise(StandardError.new('boom'))
-
-        expect(Rails.logger).to receive(:info).with(/MiniMagick failed/)
-
-        result = described_class.strip(attachable)
-
-        expect(result).to eq(attachable)
-      end
-    end
-
-    describe '.process_with_minimagick' do
-      it 'returns a tempfile containing stripped blob data' do
-        mini_magick_module = Module.new
-        image_class = Class.new do
-          def self.read(_data); end
+      context 'with a valid image attachable' do
+        let(:io) { File.open(fixture_path, 'rb') }
+        let(:attachable) do
+          {
+            io: io,
+            filename: 'image_with_gps.jpg',
+            content_type: 'image/jpeg'
+          }
         end
-        mini_magick_module.const_set(:Image, image_class)
-        stub_const('MiniMagick', mini_magick_module)
 
-        image = double('mini_magick_image')
-        allow(image).to receive(:strip)
-        allow(image).to receive(:to_blob).and_return('stripped-binary')
-        allow(MiniMagick::Image).to receive(:read).with('raw-image-data').and_return(image)
+        after do
+          io.close
+        end
 
-        tempfile = described_class.send(:process_with_minimagick, 'raw-image-data', 'jpg')
+        it 'returns a new attachable whose IO has no EXIF metadata' do
+          result = nil
+          result = described_class.strip(attachable)
 
-        expect(tempfile).to be_a(Tempfile)
-        expect(image).to have_received(:strip)
-        expect(image).to have_received(:to_blob)
+          expect(result[:io]).not_to eq(attachable[:io])
+          expect(result[:filename]).to eq('image_with_gps.jpg')
 
-        tempfile.rewind
-        expect(tempfile.read).to eq('stripped-binary')
-        expect(File.extname(tempfile.path)).to eq('.jpg')
-      ensure
-        tempfile.close! if tempfile
+          # 特定の画像処理ライブラリ（MiniMagick や Vips）に依存せず、
+          # バイナリレベルで EXIF ヘッダの有無を確認する
+          result[:io].rewind
+          stripped_data = result[:io].read
+
+          # 一般的な JPEG の Exif ヘッダシグネチャが含まれていないことを確認
+          # "Exif\0\0" は JPEG APP1 マーカー内の Exif 識別子です
+          expect(stripped_data).not_to include("Exif\0\0")
+
+          # 念のため、元のファイルには含まれていたことも確認（テストデータの妥当性保証）
+          attachable[:io].rewind
+          original_data = attachable[:io].read
+          expect(original_data).to include("Exif\0\0")
+        ensure
+          result[:io].close! if result&.dig(:io).is_a?(Tempfile)
+        end
       end
-    end
 
-    describe '.ensure_extension' do
-      it 'returns extension unchanged when already dotted' do
-        result = described_class.send(:ensure_extension, '.jpg')
-
-        expect(result).to eq('.jpg')
+      context 'when attachable is missing IO' do
+        it 'returns the original attachable unchanged' do
+          attachable = { filename: 'no-io.jpg', content_type: 'image/jpeg' }
+          expect(described_class.strip(attachable)).to eq(attachable)
+        end
       end
 
-      it 'adds a dot when extension is not dotted' do
-        result = described_class.send(:ensure_extension, 'png')
+      context 'when processing fails' do
+        it 'falls back to the original IO' do
+          io = StringIO.new('not-an-image')
+          attachable = { io: io, filename: 'bad', content_type: 'image/jpeg' }
 
-        expect(result).to eq('.png')
+          allow(described_class).to receive(:process_with_vips).and_raise(StandardError)
+          allow(described_class).to receive(:process_with_image_processing_minimagick).and_return(nil)
+          allow(described_class).to receive(:process_with_minimagick).and_return(nil)
+
+          result = described_class.strip(attachable)
+          expect(result).to eq(attachable)
+          expect(io.pos).to eq(0)
+        end
       end
-    end
+
+      context 'when all processors return nil' do
+        it 'rewinds the original io and returns attachable unchanged' do
+          io = StringIO.new('image-data')
+          io.read # advance pointer to ensure method rewinds
+          attachable = { io: io, filename: 'still-original.jpg', content_type: 'image/jpeg' }
+
+          allow(described_class).to receive(:process_with_vips).and_return(nil)
+          allow(described_class).to receive(:process_with_image_processing_minimagick).and_return(nil)
+          allow(described_class).to receive(:process_with_minimagick).and_return(nil)
+
+          result = described_class.strip(attachable)
+
+          expect(result).to eq(attachable)
+          expect(io.pos).to eq(0)
+        end
+      end
+
+      context 'when filename lacks extension' do
+        it 'infers the extension from content type' do
+          io = StringIO.new('binary-image-data')
+          attachable = { io: io, filename: 'upload', content_type: 'image/png' }
+          captured_ext = nil
+
+          allow(described_class).to receive(:process_with_vips).and_return(nil)
+          allow(described_class).to receive(:process_with_image_processing_minimagick) do |data, ext|
+            captured_ext = ext
+            nil
+          end
+          allow(described_class).to receive(:process_with_minimagick).and_return(nil)
+
+          described_class.strip(attachable)
+
+          expect(captured_ext).to eq('png')
+        end
+      end
+
+      context 'when neither filename nor content type provide image extension' do
+        it 'falls back to jpg' do
+          io = StringIO.new('binary-data')
+          attachable = { io: io, filename: 'upload', content_type: 'application/octet-stream' }
+          captured_ext = nil
+
+          allow(described_class).to receive(:process_with_vips).and_return(nil)
+          allow(described_class).to receive(:process_with_image_processing_minimagick) do |_, ext|
+            captured_ext = ext
+            nil
+          end
+          allow(described_class).to receive(:process_with_minimagick).and_return(nil)
+
+          described_class.strip(attachable)
+
+          expect(captured_ext).to eq('jpg')
+        end
+      end
+
+      context 'when MiniMagick backend raises' do
+        it 'logs the failure and returns the original attachable' do
+          io = StringIO.new('image-data')
+          attachable = { io: io, filename: 'sample.jpg', content_type: 'image/jpeg' }
+
+          allow(ImageMetadata::Stripper).to receive(:process_with_vips).and_return(nil)
+          allow(ImageMetadata::Stripper).to receive(:process_with_image_processing_minimagick).and_return(nil)
+          allow(MiniMagick::Image).to receive(:read).and_raise(StandardError.new('boom'))
+
+          expect(Rails.logger).to receive(:info).with(/MiniMagick failed/)
+
+          result = described_class.strip(attachable)
+
+          expect(result).to eq(attachable)
+        end
+      end
+
+      describe '.process_with_minimagick' do
+        it 'returns a tempfile containing stripped blob data' do
+          mini_magick_module = Module.new
+          image_class = Class.new do
+            def self.read(_data); end
+          end
+          mini_magick_module.const_set(:Image, image_class)
+          stub_const('MiniMagick', mini_magick_module)
+
+          image = double('mini_magick_image')
+          allow(image).to receive(:strip)
+          allow(image).to receive(:to_blob).and_return('stripped-binary')
+          allow(MiniMagick::Image).to receive(:read).with('raw-image-data').and_return(image)
+
+          tempfile = described_class.send(:process_with_minimagick, 'raw-image-data', 'jpg')
+
+          expect(tempfile).to be_a(Tempfile)
+          expect(image).to have_received(:strip)
+          expect(image).to have_received(:to_blob)
+
+          tempfile.rewind
+          expect(tempfile.read).to eq('stripped-binary')
+          expect(File.extname(tempfile.path)).to eq('.jpg')
+        ensure
+          tempfile.close! if tempfile
+        end
+      end
+
+      describe '.ensure_extension' do
+        it 'returns extension unchanged when already dotted' do
+          result = described_class.send(:ensure_extension, '.jpg')
+
+          expect(result).to eq('.jpg')
+        end
+
+        it 'adds a dot when extension is not dotted' do
+          result = described_class.send(:ensure_extension, 'png')
+
+          expect(result).to eq('.png')
+        end
+      end
     end
   end
 end

--- a/spec/services/image_metadata/stripper_spec.rb
+++ b/spec/services/image_metadata/stripper_spec.rb
@@ -229,6 +229,20 @@ RSpec.describe ImageMetadata::Stripper do
         tempfile.close! if tempfile
       end
     end
+
+    describe '.ensure_extension' do
+      it 'returns extension unchanged when already dotted' do
+        result = described_class.send(:ensure_extension, '.jpg')
+
+        expect(result).to eq('.jpg')
+      end
+
+      it 'adds a dot when extension is not dotted' do
+        result = described_class.send(:ensure_extension, 'png')
+
+        expect(result).to eq('.png')
+      end
+    end
     end
   end
 end


### PR DESCRIPTION
テストカバレッジを確認したところ、通っていない箇所があったので、その箇所を通るテストを追加します。

---

This pull request adds new tests to improve coverage for the internal methods of the `ImageMetadata::Stripper` service. The most important changes are the addition of tests for image processing and file extension handling.

Tests for image processing:

* Added a test for `.process_with_minimagick` to verify that it returns a `Tempfile` containing stripped blob data, and that image stripping and blob conversion are properly invoked.

Tests for file extension handling:

* Added tests for `.ensure_extension` to ensure it correctly handles file extensions, both when already dotted and when not.