### PR TITLE
メッセージ表示の改良（新規時、削除時）

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -33,8 +33,8 @@
 
 */
 
-@layer components {
-  #messages div[data-new-message="true"] {
+@layer utilities {
+  #messages [data-new-message="true"] {
     @apply bg-red-100;
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,6 +41,7 @@ module ApplicationHelper
     keys = %w[
       cable_disconnected
       new_messages_available_count
+      message_deleted
     ]
     content_tag(:ul, id: 'exported-locale-messages', style: 'display: none;') do
       safe_join(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,7 @@ module ApplicationHelper
   def exported_locale_messages
     keys = %w[
       cable_disconnected
+      new_messages_available_count
     ]
     content_tag(:ul, id: 'exported-locale-messages', style: 'display: none;') do
       safe_join(

--- a/app/javascript/channels/messages_channel.js
+++ b/app/javascript/channels/messages_channel.js
@@ -5,17 +5,23 @@ consumer.subscriptions.create("MessagesChannel", {
   connected() {
     // Called when the subscription is ready for use on the server
     console.log("MessagesChannel: connected")
-    this.messagesContainer()?.setAttribute('data-channel-connected', 'true')
-    this.boundRevealPendingMessages = this.revealPendingMessages.bind(this)
-    this.pendingNoticeButton()?.addEventListener('click', this.boundRevealPendingMessages)
-    this.updatePendingMessagesNotice()
+    this.boundDocumentClick = this.handleDocumentClick.bind(this)
+    this.boundSyncMessagesUi = this.syncMessagesUi.bind(this)
+
+    document.addEventListener('click', this.boundDocumentClick)
+    document.addEventListener('turbo:load', this.boundSyncMessagesUi)
+    document.addEventListener('turbo:render', this.boundSyncMessagesUi)
+
+    this.syncMessagesUi()
   },
 
   disconnected() {
     // Called when the subscription has been terminated by the server
     console.log("MessagesChannel: disconnected");
     this.messagesContainer()?.setAttribute('data-channel-connected', 'false')
-    this.pendingNoticeButton()?.removeEventListener('click', this.boundRevealPendingMessages)
+    document.removeEventListener('click', this.boundDocumentClick)
+    document.removeEventListener('turbo:load', this.boundSyncMessagesUi)
+    document.removeEventListener('turbo:render', this.boundSyncMessagesUi)
 
     const flashMessage = this.disconnectedMessage();
     clearFlashMessages(flashMessage);
@@ -62,8 +68,7 @@ consumer.subscriptions.create("MessagesChannel", {
   },
 
   revealPendingMessages() {
-    const messages = document.getElementById('messages');
-    if (!messages) return;
+    if (!this.messagesContainer()) return;
 
     const pending = this.pendingMessageElements()
     if (pending.length === 0) return;
@@ -79,6 +84,18 @@ consumer.subscriptions.create("MessagesChannel", {
       lastRevealed.insertAdjacentElement('afterend', this.buildSeparatorElement())
     }
 
+    this.updatePendingMessagesNotice()
+  },
+
+  handleDocumentClick(event) {
+    const revealButton = event.target.closest('[data-role="new-messages-reveal"]')
+    if (!revealButton || revealButton !== this.pendingNoticeButton()) return
+
+    this.revealPendingMessages()
+  },
+
+  syncMessagesUi() {
+    this.messagesContainer()?.setAttribute('data-channel-connected', 'true')
     this.updatePendingMessagesNotice()
   },
 

--- a/app/javascript/channels/messages_channel.js
+++ b/app/javascript/channels/messages_channel.js
@@ -34,12 +34,16 @@ consumer.subscriptions.create("MessagesChannel", {
     console.log("MessagesChannel: received", data)
 
     const messages = document.getElementById('messages');
-    if (!messages) return;
 
     const notificationTargets = document.querySelectorAll('[data-messages-channel="notification"]');
     const page = document.querySelector('[data-current-page-number]')?.dataset?.currentPageNumber; // or undefined
 
     if (data['created']) {
+      if (!messages) {
+        notificationTargets.forEach((nt) => nt.classList.remove('hidden'));
+        return;
+      }
+
       if (!page || page == '1') {
         if (this.createdByCurrentUser(messages, data)) {
           // Own posts are shown immediately and intentionally keep the same
@@ -54,6 +58,8 @@ consumer.subscriptions.create("MessagesChannel", {
       }
     }
     else if (data['destroyed']) {
+      if (!messages) return;
+
       const destroyedMessageId = String(data['destroyed'])
       messages.querySelectorAll(`[data-message-id="${destroyedMessageId}"]`).forEach((elem) => {
         if (elem.dataset['pendingMessage'] === 'true') {
@@ -198,7 +204,7 @@ consumer.subscriptions.create("MessagesChannel", {
     messageElement.classList.remove('bg-white')
     messageElement.classList.add('bg-gray-100')
 
-    const deleteLink = messageElement.querySelector('[data-testid^="delete-message-"]')
+    const deleteLink = messageElement.querySelector('[data-message-ownership-target="owner"]')
     if (deleteLink) deleteLink.remove()
 
     const body = messageElement.querySelector('[data-message-body="true"]')

--- a/app/javascript/channels/messages_channel.js
+++ b/app/javascript/channels/messages_channel.js
@@ -49,7 +49,14 @@ consumer.subscriptions.create("MessagesChannel", {
     }
     else if (data['destroyed']) {
       const destroyedMessageId = String(data['destroyed'])
-      messages.querySelectorAll(`[data-message-id="${destroyedMessageId}"]`).forEach((elem) => elem.remove())
+      messages.querySelectorAll(`[data-message-id="${destroyedMessageId}"]`).forEach((elem) => {
+        if (elem.dataset['pendingMessage'] === 'true') {
+          elem.remove()
+          return
+        }
+
+        this.convertToDeletedMessage(elem)
+      })
       this.updatePendingMessagesNotice()
     }
   },
@@ -164,6 +171,33 @@ consumer.subscriptions.create("MessagesChannel", {
 
   pendingMessageElements() {
     return Array.from(this.messagesContainer()?.querySelectorAll('[data-pending-message="true"]') || [])
+  },
+
+  convertToDeletedMessage(messageElement) {
+    if (!messageElement || messageElement.dataset['deletedMessage'] === 'true') return
+
+    messageElement.dataset.deletedMessage = 'true'
+    messageElement.removeAttribute('data-new-message')
+    messageElement.classList.remove('bg-white')
+    messageElement.classList.add('bg-gray-100')
+
+    const deleteLink = messageElement.querySelector('[data-testid^="delete-message-"]')
+    if (deleteLink) deleteLink.remove()
+
+    const body = messageElement.querySelector('[data-message-body="true"]')
+    if (body) {
+      body.textContent = this.deletedMessageText()
+      body.classList.remove('text-nowrap')
+      body.classList.add('text-gray-500', 'italic')
+    }
+
+    const attachments = messageElement.querySelector('[data-message-attachments="true"]')
+    if (attachments) attachments.innerHTML = ''
+  },
+
+  deletedMessageText() {
+    const fallback = 'This message was deleted.'
+    return this.localeMessage('message_deleted') || fallback
   },
 
   buildSeparatorElement() {

--- a/app/javascript/channels/messages_channel.js
+++ b/app/javascript/channels/messages_channel.js
@@ -5,11 +5,17 @@ consumer.subscriptions.create("MessagesChannel", {
   connected() {
     // Called when the subscription is ready for use on the server
     console.log("MessagesChannel: connected")
+    this.messagesContainer()?.setAttribute('data-channel-connected', 'true')
+    this.boundRevealPendingMessages = this.revealPendingMessages.bind(this)
+    this.pendingNoticeButton()?.addEventListener('click', this.boundRevealPendingMessages)
+    this.updatePendingMessagesNotice()
   },
 
   disconnected() {
     // Called when the subscription has been terminated by the server
     console.log("MessagesChannel: disconnected");
+    this.messagesContainer()?.setAttribute('data-channel-connected', 'false')
+    this.pendingNoticeButton()?.removeEventListener('click', this.boundRevealPendingMessages)
 
     const flashMessage = this.disconnectedMessage();
     clearFlashMessages(flashMessage);
@@ -22,26 +28,171 @@ consumer.subscriptions.create("MessagesChannel", {
     console.log("MessagesChannel: received", data)
 
     const messages = document.getElementById('messages');
+    if (!messages) return;
+
     const notificationTargets = document.querySelectorAll('[data-messages-channel="notification"]');
     const page = document.querySelector('[data-current-page-number]')?.dataset?.currentPageNumber; // or undefined
 
     if (data['created']) {
       if (!page || page == '1') {
-        messages.insertAdjacentHTML('afterbegin', data['rendered_message']);
+        if (this.createdByCurrentUser(messages, data)) {
+          // Own posts are shown immediately and intentionally keep the same
+          // temporary highlight as other newly inserted messages.
+          this.insertVisibleMessage(data['rendered_message'], { highlight: true });
+        } else {
+          this.insertPendingMessage(data['rendered_message'], { highlight: true })
+          this.updatePendingMessagesNotice();
+        }
       } else {
         notificationTargets.forEach((nt) => nt.classList.remove('hidden'));
       }
     }
     else if (data['destroyed']) {
-      const destroyed_message_id = data['destroyed']
-      const elem = messages.querySelector(`[data-message-id="${destroyed_message_id}"]`);
-      if (elem) elem.remove();
+      const destroyedMessageId = String(data['destroyed'])
+      messages.querySelectorAll(`[data-message-id="${destroyedMessageId}"]`).forEach((elem) => elem.remove())
+      this.updatePendingMessagesNotice()
     }
+  },
+
+  revealPendingMessages() {
+    const messages = document.getElementById('messages');
+    if (!messages) return;
+
+    const pending = this.pendingMessageElements()
+    if (pending.length === 0) return;
+
+    pending.forEach((message) => {
+      message.classList.remove('hidden')
+      message.removeAttribute('aria-hidden')
+      message.removeAttribute('data-pending-message')
+    })
+
+    const lastRevealed = pending[pending.length - 1]
+    if (lastRevealed) {
+      lastRevealed.insertAdjacentElement('afterend', this.buildSeparatorElement())
+    }
+
+    this.updatePendingMessagesNotice()
+  },
+
+  insertPendingMessage(renderedMessage, { highlight = true } = {}) {
+    const element = this.buildMessageElement(renderedMessage, { highlight })
+    if (!element) return
+
+    element.setAttribute('data-pending-message', 'true')
+    element.setAttribute('aria-hidden', 'true')
+    element.classList.add('hidden')
+
+    const notice = this.pendingMessagesNotice()
+    if (notice) {
+      notice.insertAdjacentElement('afterend', element)
+      return
+    }
+
+    this.messagesContainer()?.insertAdjacentElement('afterbegin', element)
+  },
+
+  insertVisibleMessage(renderedMessage, { highlight = true } = {}) {
+    const element = this.buildMessageElement(renderedMessage, { highlight })
+    if (!element) return
+
+    const notice = this.pendingMessagesNotice()
+    if (notice) {
+      notice.insertAdjacentElement('afterend', element)
+      return
+    }
+
+    this.messagesContainer()?.insertAdjacentElement('afterbegin', element)
+  },
+
+  updatePendingMessagesNotice() {
+    const notice = this.pendingMessagesNotice()
+    const button = this.pendingNoticeButton()
+    if (!notice || !button) return;
+
+    const count = this.pendingMessageElements().length
+
+    if (count === 0) {
+      notice.dataset.pendingVisible = 'false'
+      notice.classList.add('hidden')
+      button.classList.add('hidden')
+      button.textContent = ''
+      return
+    }
+
+    notice.dataset.pendingVisible = 'true'
+    button.textContent = this.pendingMessagesText(count)
+    button.classList.remove('hidden')
+    notice.classList.remove('hidden')
+  },
+
+  createdByCurrentUser(messages, data) {
+    const currentUserId = messages.dataset['currentUserId']
+    const senderUserId = data['sender_user_id'] || this.extractOwnerId(data['rendered_message'])
+    return currentUserId && senderUserId && String(currentUserId) === String(senderUserId)
+  },
+
+  extractOwnerId(renderedMessage) {
+    if (!renderedMessage) return null
+
+    const template = document.createElement('template')
+    template.innerHTML = renderedMessage.trim()
+    return template.content.firstElementChild?.dataset?.ownerId || null
+  },
+
+  messagesContainer() {
+    return document.getElementById('messages')
+  },
+
+  buildMessageElement(renderedMessage, { highlight = true } = {}) {
+    if (!renderedMessage) return null
+
+    const template = document.createElement('template')
+    template.innerHTML = renderedMessage.trim()
+    const element = template.content.firstElementChild
+    if (element && highlight) element.setAttribute('data-new-message', 'true')
+    return element
+  },
+
+  pendingMessagesNotice() {
+    return document.getElementById('new-messages-notice')
+  },
+
+  pendingNoticeButton() {
+    return this.pendingMessagesNotice()?.querySelector('[data-role="new-messages-reveal"]') || null
+  },
+
+  pendingMessageElements() {
+    return Array.from(this.messagesContainer()?.querySelectorAll('[data-pending-message="true"]') || [])
+  },
+
+  buildSeparatorElement() {
+    const wrapper = document.createElement('div')
+    wrapper.className = 'mb-2 py-2'
+    wrapper.dataset.role = 'new-messages-separator'
+    wrapper.setAttribute('aria-hidden', 'true')
+
+    const line = document.createElement('div')
+    line.className = 'w-full border-t border-blue-200'
+    wrapper.appendChild(line)
+
+    return wrapper
+  },
+
+  pendingMessagesText(count) {
+    const key = 'new_messages_available_count'
+    const fallback = `${count} new messages — click to show`
+    const template = this.localeMessage(key) || fallback
+    return template.replace('%{count}', count)
+  },
+
+  localeMessage(key) {
+    const localeMessage = document.querySelector(`#exported-locale-messages li[data-key="${key}"]`)
+    return localeMessage ? localeMessage.textContent : null
   },
 
   disconnectedMessage() {
     const fallbackMessage = "Connection to the server has been lost. Please reload the page to reconnect";
-    const localeMessage = document.querySelector('#exported-locale-messages li[data-key="cable_disconnected"]');
-    return localeMessage ? localeMessage.textContent : fallbackMessage;
+    return this.localeMessage('cable_disconnected') || fallbackMessage;
   }
 });

--- a/app/javascript/controllers/new_message_highlighter_controller.js
+++ b/app/javascript/controllers/new_message_highlighter_controller.js
@@ -4,12 +4,16 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
+    if (this.element.getAttribute('data-new-message') !== 'true') return
+
     this.boundHandleUserActivity = this.handleUserActivity.bind(this)
     this.element.addEventListener('mousemove', this.boundHandleUserActivity)
     this.element.addEventListener('focusin', this.boundHandleUserActivity)
   }
 
   disconnect() {
+    if (!this.boundHandleUserActivity) return
+
     this.element.removeEventListener('mousemove', this.boundHandleUserActivity)
     this.element.removeEventListener('focusin', this.boundHandleUserActivity)
   }
@@ -17,8 +21,9 @@ export default class extends Controller {
   handleUserActivity() {
     if (this.element.getAttribute('data-new-message') === 'true') {
       this.element.removeAttribute('data-new-message')
-      this.element.removeEventListener('mousemove', this.boundHandleUserActivity)
-      this.element.removeEventListener('focusin', this.boundHandleUserActivity)
     }
+
+    this.element.removeEventListener('mousemove', this.boundHandleUserActivity)
+    this.element.removeEventListener('focusin', this.boundHandleUserActivity)
   }
 }

--- a/app/javascript/controllers/new_message_highlighter_controller.js
+++ b/app/javascript/controllers/new_message_highlighter_controller.js
@@ -1,23 +1,23 @@
-// This Stimulus controller removes the highlight from a new message when the user hovers or focuses it.
-// ユーザーが新着メッセージにマウスを乗せるかフォーカスすると、ハイライトを解除するStimulusコントローラです。
+// This Stimulus controller removes the highlight from a new message when the user moves the pointer over it or focuses it.
+// ユーザーが新着メッセージ上でマウスを動かすかフォーカスすると、ハイライトを解除するStimulusコントローラです。
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
     this.boundHandleUserActivity = this.handleUserActivity.bind(this)
-    this.element.addEventListener('mouseenter', this.boundHandleUserActivity)
+    this.element.addEventListener('mousemove', this.boundHandleUserActivity)
     this.element.addEventListener('focusin', this.boundHandleUserActivity)
   }
 
   disconnect() {
-    this.element.removeEventListener('mouseenter', this.boundHandleUserActivity)
+    this.element.removeEventListener('mousemove', this.boundHandleUserActivity)
     this.element.removeEventListener('focusin', this.boundHandleUserActivity)
   }
 
   handleUserActivity() {
     if (this.element.getAttribute('data-new-message') === 'true') {
       this.element.removeAttribute('data-new-message')
-      this.element.removeEventListener('mouseenter', this.boundHandleUserActivity)
+      this.element.removeEventListener('mousemove', this.boundHandleUserActivity)
       this.element.removeEventListener('focusin', this.boundHandleUserActivity)
     }
   }

--- a/app/jobs/message_broadcast_job.rb
+++ b/app/jobs/message_broadcast_job.rb
@@ -19,6 +19,7 @@ class MessageBroadcastJob < ApplicationJob
     else
       ActionCable.server.broadcast('general_message_board', {
         created: message_id,
+        sender_user_id: message.user_id,
         rendered_message: render_message(message)
       })
     end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -23,9 +23,9 @@
 
   <%= content_tag :div, simple_format(message.content),
     class: "container text-nowrap",
-    **data_with_testid("message-content-#{message.id}") %>
+    **data_with_testid("message-content-#{message.id}", message_body: true) %>
 
-  <div class="container flex">
+  <div class="container flex" data-message-attachments="true">
     <% if message.attachments.attached? %>
       <% message.attachments.each do |att| %>
         <div class="container shrink-0 w-auto mx-2">

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -108,7 +108,10 @@
         <%= paginate @messages %>
       </div>
 
-      <div id="messages" class="container">
+      <div id="messages" class="container" data-current-user-id="<%= current_user.id %>">
+        <div id="new-messages-notice" class="hidden mb-2" data-pending-visible="false">
+          <button type="button" class="w-full rounded-lg border border-blue-200 bg-blue-100 px-4 py-2 text-sm text-blue-700 hover:bg-blue-200" data-role="new-messages-reveal"></button>
+        </div>
         <%= render @messages %>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,7 @@ en:
       too_short: "is too short (minimum is %{count} characters)"
   exports:
     cable_disconnected: "Connection to the server has been lost. Please reload the page to reconnect."
+    message_deleted: "This message was deleted."
     new_messages_available_count: "%{count} new messages — click to show"
   helpers:
     page_entries_info:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,7 @@ en:
       too_short: "is too short (minimum is %{count} characters)"
   exports:
     cable_disconnected: "Connection to the server has been lost. Please reload the page to reconnect."
+    new_messages_available_count: "%{count} new messages — click to show"
   helpers:
     page_entries_info:
       more_pages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -97,6 +97,7 @@ ja:
       too_short: "は%{count}文字以上で入力してください"
   exports:
     cable_disconnected: "サーバーとの接続が切れました。再接続するには画面をリロードしてください。"
+    message_deleted: "このメッセージは削除されました。"
     new_messages_available_count: "新着メッセージが%{count}件あります。クリックで表示します。"
   helpers:
     page_entries_info:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -97,6 +97,7 @@ ja:
       too_short: "は%{count}文字以上で入力してください"
   exports:
     cable_disconnected: "サーバーとの接続が切れました。再接続するには画面をリロードしてください。"
+    new_messages_available_count: "新着メッセージが%{count}件あります。クリックで表示します。"
   helpers:
     page_entries_info:
       more_pages:

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -213,6 +213,26 @@ RSpec.describe 'Messages Form', type: :system do
       expect(page).not_to have_selector("[data-testid='delete-message-#{message.id}']")
     end
 
+    it 'keeps deleted messages as tombstones with metadata' do
+      other_user = create(:user, :confirmed, username: 'otheruser')
+      message = create(:message, user: other_user, content: 'to be deleted')
+      visit messages_path
+
+      target = find("[data-message-id='#{message.id}']")
+      expect(target).to have_content('to be deleted')
+      expect(target).to have_content('otheruser')
+
+      message.destroy!
+      MessageBroadcastJob.perform_now(message.id)
+
+      tombstone = find("[data-message-id='#{message.id}']", wait: 5)
+      expect(tombstone['data-deleted-message']).to eq('true')
+      expect(tombstone).to have_content(I18n.t('exports.message_deleted'))
+      expect(tombstone).to have_content('otheruser')
+      expect(tombstone).not_to have_content('to be deleted')
+      expect(tombstone).to have_no_selector('[data-testid^="delete-message-"]')
+    end
+
     it 'renders metadata checkboxes using user defaults' do
       confirmed_user.update(default_strip_metadata: false, default_allow_location_public: true)
       visit current_path

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe 'Messages Form', type: :system do
       other_user = create(:user, :confirmed, username: 'otheruser')
       message = create(:message, user: other_user, content: 'to be deleted')
       visit messages_path
+      expect(page).to have_css('#messages[data-channel-connected="true"]', wait: 5)
 
       target = find("[data-message-id='#{message.id}']")
       expect(target).to have_content('to be deleted')

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -59,6 +59,41 @@ RSpec.describe 'Messages Form', type: :system do
       expect(page).to have_content('This is a test message')
     end
 
+    it 'highlights a newly posted message until the user interacts with it' do
+      create(:message, user: confirmed_user, content: 'Existing message')
+      visit current_path
+
+      existing_message = find('[data-message-id]', text: 'Existing message')
+      existing_message_id = existing_message['data-message-id']
+      existing_background = page.evaluate_script(
+        "getComputedStyle(document.querySelector('[data-message-id=\"#{existing_message_id}\"]')).backgroundColor"
+      )
+
+      fill_in 'comment', with: 'Highlighted new message'
+      click_button I18n.t('messages.form.post')
+
+      new_message = find('[data-message-id]', text: 'Highlighted new message', wait: 5)
+      new_message_id = new_message['data-message-id']
+      new_background = page.evaluate_script(
+        "getComputedStyle(document.querySelector('[data-message-id=\"#{new_message_id}\"]')).backgroundColor"
+      )
+
+      expect(new_message['data-new-message']).to eq('true')
+      expect(new_background).not_to eq(existing_background)
+
+      page.execute_script(<<~JS)
+        const message = document.querySelector('[data-message-id="#{new_message_id}"]')
+        message.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }))
+      JS
+
+      cleared_background = page.evaluate_script(
+        "getComputedStyle(document.querySelector('[data-message-id=\"#{new_message_id}\"]')).backgroundColor"
+      )
+
+      expect(page).to have_no_selector("[data-message-id='#{new_message_id}'][data-new-message='true']")
+      expect(cleared_background).to eq(existing_background)
+    end
+
     it 'shows a generic error message when message creation fails' do
       allow_any_instance_of(MessagesController).to receive(:create_message!).and_raise(StandardError, 'Simulated failure!')
       visit messages_path

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Messages Form', type: :system do
 
       page.execute_script(<<~JS)
         const message = document.querySelector('[data-message-id="#{new_message_id}"]')
-        message.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }))
+        message.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }))
       JS
 
       cleared_background = page.evaluate_script(
@@ -92,6 +92,72 @@ RSpec.describe 'Messages Form', type: :system do
 
       expect(page).to have_no_selector("[data-message-id='#{new_message_id}'][data-new-message='true']")
       expect(cleared_background).to eq(existing_background)
+    end
+
+    it 'queues messages from other users until the reveal line is clicked' do
+      create(:message, user: confirmed_user, content: 'Older visible message')
+      visit current_path
+
+      expect(page).to have_css('#messages[data-channel-connected="true"]', wait: 5)
+      reference_message = find('[data-message-id]', text: 'Older visible message')
+      reference_message_id = reference_message['data-message-id']
+      existing_background = page.evaluate_script(
+        "getComputedStyle(document.querySelector('[data-message-id=\"#{reference_message_id}\"]')).backgroundColor"
+      )
+
+      other_user = create(:user, :confirmed)
+      incoming_message_1 = create(:message, user: other_user, content: 'Incoming message one')
+      incoming_message_2 = create(:message, user: other_user, content: 'Incoming message two')
+
+      MessageBroadcastJob.perform_now(incoming_message_1.id)
+      MessageBroadcastJob.perform_now(incoming_message_2.id)
+
+      expect(page).to have_css('#new-messages-notice[data-pending-visible="true"] [data-role="new-messages-reveal"]', wait: 5)
+      expect(page).not_to have_content('Incoming message one')
+      expect(page).not_to have_content('Incoming message two')
+
+      fill_in 'comment', with: 'My visible message'
+      click_button I18n.t('messages.form.post')
+      expect(page).to have_content('My visible message')
+
+      first_child_id = page.evaluate_script("document.querySelector('#messages').firstElementChild.id")
+      expect(first_child_id).to eq('new-messages-notice')
+
+      find('[data-role="new-messages-reveal"]', visible: true).click
+
+      message_one = find('[data-message-id]', text: 'Incoming message one')
+      message_two = find('[data-message-id]', text: 'Incoming message two')
+      background_one = page.evaluate_script(
+        "getComputedStyle(document.querySelector('[data-message-id=\"#{message_one['data-message-id']}\"]')).backgroundColor"
+      )
+      background_two = page.evaluate_script(
+        "getComputedStyle(document.querySelector('[data-message-id=\"#{message_two['data-message-id']}\"]')).backgroundColor"
+      )
+
+      expect(page).to have_css('[data-role="new-messages-separator"]', wait: 5)
+      expect(page).to have_css('#new-messages-notice[data-pending-visible="false"]', wait: 5, visible: :all)
+      expect(page.all('[data-role="new-messages-separator"]', visible: true).size).to eq(1)
+      separator_has_message_above = page.evaluate_script(<<~JS)
+        (() => {
+          const sep = [...document.querySelectorAll('[data-role="new-messages-separator"]')].at(-1)
+          return !!(sep && sep.previousElementSibling && sep.previousElementSibling.dataset && sep.previousElementSibling.dataset.messageId)
+        })()
+      JS
+      expect(separator_has_message_above).to be(true)
+      expect(background_one).not_to eq(existing_background)
+      expect(background_two).not_to eq(existing_background)
+
+      incoming_message_3 = create(:message, user: other_user, content: 'Incoming message three')
+      MessageBroadcastJob.perform_now(incoming_message_3.id)
+
+      first_child_role = page.evaluate_script("document.querySelector('#messages').firstElementChild.querySelector('[data-role]')?.dataset.role")
+      expect(first_child_role).to eq('new-messages-reveal')
+      expect(page).to have_css('[data-role="new-messages-separator"]', wait: 5)
+      expect(page).not_to have_content('Incoming message three')
+
+      find('[data-role="new-messages-reveal"]', visible: true).click
+      expect(page).to have_content('Incoming message three')
+      expect(page.all('[data-role="new-messages-separator"]', visible: true).size).to eq(2)
     end
 
     it 'shows a generic error message when message creation fails' do

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -232,6 +232,23 @@ RSpec.describe 'Messages Form', type: :system do
       expect(tombstone).to have_content('otheruser')
       expect(tombstone).not_to have_content('to be deleted')
       expect(tombstone).to have_no_selector('[data-testid^="delete-message-"]')
+      expect(tombstone).to have_no_selector('[data-message-ownership-target="owner"]')
+    end
+
+    it 'shows notification badge when messages container is not present' do
+      visit messages_path
+      expect(page).to have_css('#messages[data-channel-connected="true"]', wait: 5)
+
+      page.execute_script(<<~JS)
+        document.getElementById('messages')?.remove()
+        document.querySelectorAll('[data-messages-channel="notification"]').forEach((badge) => badge.classList.add('hidden'))
+      JS
+
+      other_user = create(:user, :confirmed)
+      incoming_message = create(:message, user: other_user, content: 'Notification when messages is missing')
+      MessageBroadcastJob.perform_now(incoming_message.id)
+
+      expect(page).to have_css('[data-messages-channel="notification"]:not(.hidden)', wait: 5)
     end
 
     it 'renders metadata checkboxes using user defaults' do


### PR DESCRIPTION
他のユーザーからの新規投稿されたメッセージの表示の仕方について、これまでは単にメッセージ１個のコンテナを挿入するだけでしたが、ツイッターのように、 "新規メッセージがあります" という表示を最新のメッセージの上に表示し、ユーザーのクリックによってそれらが表示されるようにします。

また削除されたメッセージの表示の仕方について、これまでは単にそのメッセージ要素を取り除いていましたが、 "メッセージは削除されました" という内容に差し替えるようにし、その位置にメッセージがあったことを残すようにします。これはそのメッセージのレコードは削除しますので、画面はリロードによって "メッセージは削除されました" の表示もなくなります。

なおこの削除の処理については、このアプリの当初のコンセプト（ LAN 内の個人用のメッセージング用途）からすると妥当であるのですが、将来的には削除したことも履歴として残すようにする拡張も構想にあります（ #169 )

---

This pull request implements a major upgrade to the real-time messaging UI, focusing on improving the handling and display of new and deleted messages. Notably, it introduces a "pending messages" queue for new messages from other users, a user-initiated reveal mechanism, and a more robust system for showing deleted messages as tombstones rather than removing them outright. The changes also include enhancements to message highlighting and localization, along with comprehensive system tests for these new behaviors.

**Real-time message handling and UI improvements:**

- Added a "pending messages" system: new messages from other users are queued and hidden until the user clicks a reveal button, which then displays them with a separator and highlight. Own messages appear immediately. (`app/javascript/channels/messages_channel.js`, `app/views/messages/index.html.erb`, `app/assets/tailwind/application.css`, `config/locales/en.yml`, `config/locales/ja.yml`, `app/helpers/application_helper.rb`, `app/jobs/message_broadcast_job.rb`, `app/views/messages/_message.html.erb`) [[1]](diffhunk://#diff-e05eb0584c759dedcd65fc0e88a79689c1780cbadec6fc19c320aedb90b973deR31-R230) [[2]](diffhunk://#diff-f5da5f1f74c5915b9908401761d10bad42f7eebb1d78f6dea690ab6e8b678107L111-R114) [[3]](diffhunk://#diff-824082aab0a95adb8b632a5c383dd6ffb733b0899d4ba594a8380882467eba82L36-R37) [[4]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R100-R101) [[5]](diffhunk://#diff-b85e8d609d1ca8ea9aef96cf26c7011d39b5dd2e7de34dd4c52d931979917508R100-R101) [[6]](diffhunk://#diff-5f3fc5e3977d242572aa1d08551f5eb557de0ccaff30370838ee9df5386ea0daR43-R44) [[7]](diffhunk://#diff-3a906cfb2398b6f997843742f0a11c1a28558ae2335862fb2b4e481c598c68a3R22) [[8]](diffhunk://#diff-93e27b58f8ea873bc6e16bdb21f29b7ac4fd587ea17ee7e257b859dea70d97c7L26-R28)

- Deleted messages are now shown as tombstones with metadata instead of being removed from the DOM, improving context and auditability. (`app/javascript/channels/messages_channel.js`, `app/views/messages/_message.html.erb`, `config/locales/en.yml`, `config/locales/ja.yml`) [[1]](diffhunk://#diff-e05eb0584c759dedcd65fc0e88a79689c1780cbadec6fc19c320aedb90b973deR31-R230) [[2]](diffhunk://#diff-93e27b58f8ea873bc6e16bdb21f29b7ac4fd587ea17ee7e257b859dea70d97c7L26-R28) [[3]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R100-R101) [[4]](diffhunk://#diff-b85e8d609d1ca8ea9aef96cf26c7011d39b5dd2e7de34dd4c52d931979917508R100-R101)

**User interaction and highlighting:**

- Improved new message highlighting: highlights are now removed on pointer movement (mousemove) or focus, for better accessibility and usability. (`app/javascript/controllers/new_message_highlighter_controller.js`)

**Localization and accessibility:**

- Added new locale keys and export logic for "message deleted" and "new messages available" notices, supporting both English and Japanese. (`config/locales/en.yml`, `config/locales/ja.yml`, `app/helpers/application_helper.rb`) [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R100-R101) [[2]](diffhunk://#diff-b85e8d609d1ca8ea9aef96cf26c7011d39b5dd2e7de34dd4c52d931979917508R100-R101) [[3]](diffhunk://#diff-5f3fc5e3977d242572aa1d08551f5eb557de0ccaff30370838ee9df5386ea0daR43-R44)

**Testing:**

- Added comprehensive system tests to verify new message highlighting, the pending messages queue, reveal behavior, and deleted message tombstones. (`spec/system/messages_spec.rb`) [[1]](diffhunk://#diff-31a729e2818292d99229e0f5864a2e8d2b4188acfd6b29044007826732e17e66R62-R162) [[2]](diffhunk://#diff-31a729e2818292d99229e0f5864a2e8d2b4188acfd6b29044007826732e17e66R216-R235)