### PR TITLE
プロフィール更新エラー時のURL修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,7 @@ class UsersController < ApplicationController
         redirect_to edit_profile_path
       end
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,7 +42,9 @@ class UsersController < ApplicationController
   private
 
   def set_user
-    @user = current_user
+    # current_user は認証・レイアウト表示でも参照されるため、フォーム用の @user とは分離して扱います。
+    # 同一インスタンスを共有すると、未保存の変更が他の表示へ意図せず漏れることがあります。
+    @user = User.find(current_user.id)
   end
 
   def user_params_for_profile

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <%= users_frame('users.edit.profile') do %>
-  <%= form_for(@user, url: update_profile_path, html: { method: :patch, class: "space-y-6", data: { turbo: false } }) do |f| %>
+  <%= form_for(@user, url: update_profile_path, html: { method: :patch, class: "space-y-6", data: { turbo_frame: '_top' } }) do |f| %>
     <%= render "shared/error_messages", resource: @user %>
 
     <div class="mb-6">

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe UsersController, type: :request do
     context "with invalid params" do
       it "renders edit template" do
         patch update_profile_path(locale: I18n.locale), params: { user: { username: "" } }
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include("Username can&#39;t be blank")
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe UsersController, type: :request do
     context "when changing preferred language to an unsupported locale" do
       it "does not change the preferred language and shows an error" do
         patch update_profile_path(locale: I18n.locale), params: { user: { preferred_language: "unsupported" } }
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(user.reload.preferred_language).not_to eq("unsupported")
         expect(response.body).to include("Display Language is not a valid locale")
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe UsersController, type: :request do
     context "with invalid params" do
       it "renders edit template" do
         patch update_profile_path(locale: I18n.locale), params: { user: { username: "" } }
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("Username can&#39;t be blank")
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe UsersController, type: :request do
     context "when changing preferred language to an unsupported locale" do
       it "does not change the preferred language and shows an error" do
         patch update_profile_path(locale: I18n.locale), params: { user: { preferred_language: "unsupported" } }
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(user.reload.preferred_language).not_to eq("unsupported")
         expect(response.body).to include("Display Language is not a valid locale")
       end

--- a/spec/system/user_profile_spec.rb
+++ b/spec/system/user_profile_spec.rb
@@ -209,5 +209,17 @@ RSpec.describe 'User profile editing', type: :system do
       expect(page).to have_selector("[data-testid='account-preferred-language']")
       expect(page).to have_field('Username')
     end
+
+    it 'does not replace header username with invalid input value' do
+      visit edit_profile_path
+
+      create(:user, :confirmed, username: 'already_taken_username')
+      fill_in 'Username', with: 'already_taken_username'
+      click_button 'Update'
+
+      expect(page).to have_content('Username has already been taken')
+      expect(page).to have_selector("[data-testid='current-user-display']", text: 'testuser')
+      expect(page).to have_field('Username', with: 'already_taken_username')
+    end
   end
 end

--- a/spec/system/user_profile_spec.rb
+++ b/spec/system/user_profile_spec.rb
@@ -192,4 +192,22 @@ RSpec.describe 'User profile editing', type: :system do
       expect(page).to have_field('ユーザー名')
     end
   end
+
+  describe 'Reload after validation errors' do
+    it 'keeps showing profile edit form after reload' do
+      visit edit_profile_path
+
+      create(:user, :confirmed, username: 'already_taken_username')
+      fill_in 'Username', with: 'already_taken_username'
+      click_button 'Update'
+
+      expect(page).to have_content('Username has already been taken')
+
+      page.refresh
+
+      expect(page).to have_current_path('/en/profile/edit')
+      expect(page).to have_selector("[data-testid='account-preferred-language']")
+      expect(page).to have_field('Username')
+    end
+  end
 end


### PR DESCRIPTION
プロフィール編集画面からフォームを送信し、バリデーションエラーになった場合に、 URL が変化してしまっていたため、そのまま画面をリロードするとルーティングエラーになってしまっていました。これを修正します。

---

This pull request improves the user profile update flow, especially around validation errors and form handling. The main focus is on ensuring proper error status codes, preventing unintended data leaks between user instances, and enhancing the user experience when validation errors occur.

**Validation and Error Handling Improvements:**

* The `update` action in `UsersController` now renders the edit form with a `422 Unprocessable Entity` status when validation fails, instead of the default `200 OK`. This makes error handling clearer for both users and client-side code.
* Request specs have been updated to expect the new `unprocessable_entity` status code when invalid parameters are submitted, ensuring tests match the improved behavior. [[1]](diffhunk://#diff-fb59d6ac7d0fdc52289e4914ed0a7a0e2035a0bbffee1817fc78eba041a3acbcL38-R38) [[2]](diffhunk://#diff-fb59d6ac7d0fdc52289e4914ed0a7a0e2035a0bbffee1817fc78eba041a3acbcL95-R95)

**Form Handling and User Instance Isolation:**

* The `set_user` method now loads a fresh `User` instance from the database instead of using `current_user` directly. This prevents unsaved changes in the form object from leaking into other parts of the application that use `current_user`.

**Frontend and UX Enhancements:**

* The `form_for` in `edit.html.erb` now uses `data: { turbo_frame: '_top' }` to ensure proper frame targeting, improving compatibility with Turbo and avoiding issues with navigation after form submission.
* New system tests verify that after a validation error, reloading the edit page preserves the form state and does not overwrite the header username with invalid data, ensuring a consistent and predictable user experience.