### PR TITLE
レスポンスステータスの修正 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,7 @@ class UsersController < ApplicationController
         redirect_to edit_profile_path
       end
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe UsersController, type: :request do
     context "with invalid params" do
       it "renders edit template" do
         patch update_profile_path(locale: I18n.locale), params: { user: { username: "" } }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("Username can&#39;t be blank")
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe UsersController, type: :request do
     context "when changing preferred language to an unsupported locale" do
       it "does not change the preferred language and shows an error" do
         patch update_profile_path(locale: I18n.locale), params: { user: { preferred_language: "unsupported" } }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(user.reload.preferred_language).not_to eq("unsupported")
         expect(response.body).to include("Display Language is not a valid locale")
       end

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -226,8 +226,8 @@ RSpec.describe 'Messages Form', type: :system do
       message.destroy!
       MessageBroadcastJob.perform_now(message.id)
 
-      tombstone = find("[data-message-id='#{message.id}']", wait: 5)
-      expect(tombstone['data-deleted-message']).to eq('true')
+      expect(page).to have_css("[data-message-id='#{message.id}'][data-deleted-message='true']", wait: 5)
+      tombstone = find("[data-message-id='#{message.id}'][data-deleted-message='true']")
       expect(tombstone).to have_content(I18n.t('exports.message_deleted'))
       expect(tombstone).to have_content('otheruser')
       expect(tombstone).not_to have_content('to be deleted')


### PR DESCRIPTION
`unprocessable_entity` は非推奨になっているので `unprocessable_content` に直します。前回 #171 の Copilot からの指摘で unprocessable_entity にしてしまっていました。

追加の修正で、 CI で１件、 system spec がエラーになる箇所があったので、要素の表示タイミングの問題と見て調整しています。

```
Failures:

  1) Messages Form when the user is confirmed keeps deleted messages as tombstones with metadata
     Failure/Error: expect(tombstone['data-deleted-message']).to eq('true')

       expected: "true"
            got: nil

       (compared using ==)

     [Screenshot Image]: /home/runner/work/Annabelle/Annabelle/tmp/capybara/failures_r_spec_example_groups_messages_form_when_the_user_is_confirmed_keeps_deleted_messages_as_tombstones_with_metadata_164.png 


     # ./spec/system/messages_spec.rb:230:in 'block (3 levels) in <top (required)>'
```

---

This pull request primarily updates the HTTP status symbol used for unprocessable requests in the user profile update flow and adjusts related tests accordingly. Additionally, it improves the reliability of a system test for message deletion.

**HTTP Status Symbol Update:**

* Changed the status symbol from `:unprocessable_entity` to `:unprocessable_content` when rendering the `edit` template in the `UsersController`'s `update` action.
* Updated request specs in `users_controller_spec.rb` to expect the new `:unprocessable_content` status instead of `:unprocessable_entity` for invalid user profile update scenarios. [[1]](diffhunk://#diff-fb59d6ac7d0fdc52289e4914ed0a7a0e2035a0bbffee1817fc78eba041a3acbcL38-R38) [[2]](diffhunk://#diff-fb59d6ac7d0fdc52289e4914ed0a7a0e2035a0bbffee1817fc78eba041a3acbcL95-R95)

**System Test Improvement:**

* Improved the message deletion test in `messages_spec.rb` by using `have_css` to assert the presence of the deleted message tombstone before attempting to find and inspect it, making the test more robust.