### PR TITLE
Release v1.8.1

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,7 @@
 #   # which is just to keep the container running.
 #   # The Rails server will NOT start automatically,
 #   # so please operate inside the container as described below.
+#   # SQLite helper services are excluded from the default startup.
 #   $ docker compose up --build
 #
 # 2. In another terminal, enter the container
@@ -31,10 +32,12 @@
 #   http://127.0.0.1:1080/
 #
 #   # SQLite Web UI
+#   $ docker compose --profile tools up sqlite-web
+#   # Then access:
 #   http://127.0.0.1:8080/
 #
 #   # SQLite CLI
-#   $ docker compose run --rm sqlite sqlite3 /rails/storage/development.sqlite3
+#   $ docker compose run --rm sqlite /rails/storage/development.sqlite3
 #
 # development 環境用 compose.yml
 #
@@ -45,6 +48,7 @@
 #   # これによりコンテナ内で /bin/sh が起動しますが、
 #   # これはコンテナを維持するためだけのものです。
 #   # Rails サーバーは起動しませんので、後に述べるようにコンテナ内で操作してください。
+#   # SQLite 補助サービスはデフォルトでは起動しません。
 #   $ docker compose up --build
 #
 # 2. 別ターミナルでコンテナ内にはいる
@@ -68,10 +72,12 @@
 #   http://127.0.0.1:1080/
 #
 #   # SQLite Web UI
+#   $ docker compose --profile tools up sqlite-web
+#   # 起動後にアクセス:
 #   http://127.0.0.1:8080/
 #
 #   # SQLite CLI
-#   $ docker compose run --rm sqlite sqlite3 /rails/storage/development.sqlite3
+#   $ docker compose run --rm sqlite /rails/storage/development.sqlite3
 #
 services:
   web:
@@ -110,6 +116,7 @@ services:
 
   sqlite:
     # DBメンテナンス用サービス — 詳細は docker/sqlite/Dockerfile を参照
+    profiles: ["tools"]
     build:
       context: ./docker/sqlite
     volumes:
@@ -119,6 +126,7 @@ services:
 
   sqlite-web:
     # SQLite をブラウザで操作するための Web UI (coleifer/sqlite-web)
+    profiles: ["tools"]
     image: coleifer/sqlite-web
     platform: linux/amd64
     volumes:

--- a/docker/sqlite/Dockerfile
+++ b/docker/sqlite/Dockerfile
@@ -1,6 +1,6 @@
 # この Dockerfile は、Docker ボリューム (storage) に保存された SQLite データベース
 # ファイルにコンテナ内からアクセス・操作するためのイメージを作成します。
-# 例: `docker compose run --rm sqlite sqlite3 /rails/storage/development.sqlite3`
+# 例: `docker compose run --rm sqlite /rails/storage/development.sqlite3`
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y sqlite3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 WORKDIR /data

--- a/docs/DEVELOPMENT.ja.md
+++ b/docs/DEVELOPMENT.ja.md
@@ -13,7 +13,7 @@ Compose の設定によって、カレント・ディレクトリがコンテナ
 
 ### A-1. ビルド、コンテナ起動
 
-これによりコンテナ内で Rails コンソールが起動しますが、これはコンテナを維持するためだけのものです。
+これによりコンテナ内で /bin/sh が起動しますが、これはコンテナを維持するためだけのものです。
 Rails サーバーは起動しませんので、その後に述べるようにコンテナ内で操作してください。
 
 ```
@@ -26,13 +26,14 @@ $ docker compose up --build
 
 Rails に関するコマンドはコンテナ内で実行します。以下の例では、ホスト側のシェルから `docker compose exec web ...` を使って実行しています。
 
-初回は、データベースのセットアップを行ってください。
+初回は、データベースのセットアップと CSS の最初のビルドを行ってください。
 
 ```
 $ docker compose exec web bin/rails db:prepare
+$ docker compose exec web bin/rails tailwindcss:build
 ```
 
-開発状況に応じて、サーバーの起動やマイグレーションなど、任意の Rails コマンドをコンテナ内で実行します。
+その後は開発状況に応じて、サーバーの起動やマイグレーションなど、任意の Rails コマンドをコンテナ内で実行します。
 
 ```
 # サーバー起動
@@ -42,6 +43,18 @@ $ docker compose exec web bin/rails s -b 0.0.0.0 -p 3000
 ```
 # マイグレーションなどの Rails コマンド
 $ docker compose exec web bin/rails db:migrate
+```
+
+データベースは Docker ボリューム内に配置されているため、 SQLite コマンドはコンテナ内から実行する必要があります。コマンドラインから操作したい場合は、次のワンショット実行を使ってください。
+
+```
+$ docker compose run --rm sqlite /rails/storage/development.sqlite3
+```
+
+またデータベースを Web UI で操作したい場合は、 `sqlite-web` を利用できます。コンテナを起動し、ブラウザで `8080` ポートにアクセスしてください。
+
+```
+$ docker compose --profile tools up sqlite-web
 ```
 
 ### A-3. ホスト上のブラウザでアクセス

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,7 +15,7 @@ With the Compose settings, the current directory on the host is mounted as the t
 
 ### A-1. Build and start the container
 
-This starts a Rails console inside the container, which is used only to keep the container running.
+This starts a /bin/sh shell inside the container, which is used only to keep the container running.
 The Rails server does not start automatically, so continue operating inside the container as described below.
 
 ```
@@ -28,13 +28,14 @@ Before running the application, make sure to set the required environment variab
 
 Rails-related commands should be run inside the container. In the examples below, the commands are executed from the host shell by using `docker compose exec web ...`.
 
-On the first run, set up the database manually as follows:
+On the first run, prepare the database and perform the initial CSS build.
 
 ```
 $ docker compose exec web bin/rails db:prepare
+$ docker compose exec web bin/rails tailwindcss:build
 ```
 
-Depending on your development needs, you can run any Rails command inside the container, such as starting the server or running migrations.
+After that, depending on your development needs, you can run any Rails command inside the container, such as starting the server or running migrations.
 
 ```
 # Start the server
@@ -44,6 +45,18 @@ $ docker compose exec web bin/rails s -b 0.0.0.0 -p 3000
 ```
 # Run migrations or other Rails commands
 $ docker compose exec web bin/rails db:migrate
+```
+
+Because the database is stored in a Docker volume, SQLite commands need to be run from inside a container. If you want to work with it from the command line, use the following one-shot command.
+
+```
+$ docker compose run --rm sqlite /rails/storage/development.sqlite3
+```
+
+If you want to use a Web UI for the database, you can use `sqlite-web`. Start the container, then access port `8080` in your browser.
+
+```
+$ docker compose --profile tools up sqlite-web
 ```
 
 ### A-3. Access from your browser on the host


### PR DESCRIPTION
環境構築手順に不備があったため、その修正だけでもリリースします。

---

# Release v1.8.1

アプリケーションの主な機能に変更はありません。  
`v1.8.0` 公開後に確認された、Docker Compose を使った開発環境構築時の SQLite 初期化まわりの問題を修正するためのパッチリリースです。

通常の `docker compose up --build` では SQLite 補助サービス (`sqlite`, `sqlite-web`) が自動起動しないようにし、初回セットアップ時にデータベースファイルが意図せず作成されることによる権限問題を避けるようにしました。あわせて、日本語版・英語版の開発ドキュメントを更新し、初回の `db:prepare`、`tailwindcss:build`、SQLite CLI / Web UI の利用手順を整理しています。
