### PR TITLE
Action Cable 購読に認証を要求するようにする

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,15 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+      def find_verified_user
+        env['warden']&.user || reject_unauthorized_connection
+      end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,6 +6,7 @@ class Users::SessionsController < Devise::SessionsController
 
   protect_from_forgery with: :exception, prepend: true, except: :destroy
   before_action :store_language_for_logout, only: [:destroy]  # ログアウト前に言語設定を保存
+  before_action :disconnect_action_cable_connections, only: [:destroy]
 
   # (override)
   # デフォルトの root_path はログインが必須なため、ログイン画面へリダイレクトします。
@@ -23,6 +24,14 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   private
+
+  def disconnect_action_cable_connections
+    return unless current_user
+
+    ActionCable.server.remote_connections.where(current_user: current_user).disconnect
+  rescue StandardError => e
+    Rails.logger.warn("[ActionCable] Failed to disconnect user connections on logout: #{e.class}: #{e.message}")
+  end
 
   def store_language_for_logout
     # 現在の言語設定を一時的に保存

--- a/spec/channels/messages_channel_spec.rb
+++ b/spec/channels/messages_channel_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe MessagesChannel, type: :channel do
+  let(:user) { create(:user) }
+
+  it 'subscribes authenticated users to the general message board' do
+    stub_connection current_user: user
+
+    subscribe
+
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_from('general_message_board')
+  end
+end

--- a/spec/connection/application_cable/connection_spec.rb
+++ b/spec/connection/application_cable/connection_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Connection, type: :connection do
+  include ActionCable::Connection::TestCase::Behavior
+  include ActionCable::Connection::Assertions
+
+  tests ApplicationCable::Connection
+
+  let(:user) { create(:user) }
+  let(:warden) { instance_double(Warden::Proxy, user: warden_user) }
+
+  context 'when the session is authenticated' do
+    let(:warden_user) { user }
+
+    it 'connects successfully' do
+      connect '/cable', env: { 'warden' => warden }
+
+      expect(connection.current_user).to eq(user)
+    end
+  end
+
+  context 'when the session is not authenticated' do
+    let(:warden_user) { nil }
+
+    it 'rejects the connection' do
+      assert_reject_connection { connect '/cable', env: { 'warden' => warden } }
+    end
+  end
+end

--- a/spec/requests/users/sessions_controller_spec.rb
+++ b/spec/requests/users/sessions_controller_spec.rb
@@ -191,4 +191,32 @@ RSpec.describe Users::SessionsController, type: :request do
       end
     end
   end
+
+  describe 'ログアウト時の Action Cable 接続切断' do
+    let(:remote_connections) { double('RemoteConnections') }
+    let(:disconnect_scope) { double('RemoteConnectionScope', disconnect: true) }
+
+    before do
+      sign_in user
+      allow(ActionCable.server).to receive(:remote_connections).and_return(remote_connections)
+      allow(remote_connections).to receive(:where).and_return(disconnect_scope)
+    end
+
+    it '現在のユーザーの接続を切断する' do
+      delete destroy_user_session_path
+
+      expect(remote_connections).to have_received(:where).with(
+        hash_including(current_user: have_attributes(id: user.id))
+      )
+      expect(disconnect_scope).to have_received(:disconnect)
+    end
+
+    it '切断に失敗してもログアウトを継続する' do
+      allow(remote_connections).to receive(:where).and_raise(StandardError, 'disconnect failed')
+
+      delete destroy_user_session_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
 end


### PR DESCRIPTION
Action Cable の接続に認証がかかっていないため、 URL が分かればログインなしにメッセージを購読できてしまいますので、ログインユーザであることを確認するようにします。またログアウト時には、全ての購読を切断するようにします。

---

## Summary

This PR hardens Action Cable access in two places:

1. require an authenticated Devise/Warden session before accepting a WebSocket connection
2. disconnect existing Action Cable connections for the current user when they log out

## Changes

- add `identified_by :current_user` to `ApplicationCable::Connection`
- authenticate Action Cable connections via `env["warden"]`
- reject unauthorized WebSocket connections with `reject_unauthorized_connection`
- disconnect remote Action Cable connections for the current user during logout
- keep logout working even if remote disconnect fails
- add channel and connection specs for authenticated and unauthenticated connection flows
- add request specs covering logout-triggered disconnect behavior

## Why

Previously, the messages channel could be subscribed to without verifying the WebSocket connection at connect time.

After hardening the connect path, one gap still remained: if a user logged out in one tab, another already-connected tab could keep receiving broadcasts over an existing WebSocket connection until that connection naturally closed or reconnected.

This PR closes both issues by:

- preventing unauthenticated new connections
- explicitly disconnecting active connections for the logging-out user

## Validation

- `bundle exec rspec`
- `bundle exec rubocop --format simple`