### PR TITLE
ファイルサイズのバリデーション追加

### DIFF
--- a/app/models/concerns/factory.rb
+++ b/app/models/concerns/factory.rb
@@ -167,13 +167,15 @@ module Factory
     end
 
     def attachment_io_byte_size(upload)
-      if upload.respond_to?(:size)
-        upload.size.to_i
-      elsif upload.respond_to?(:tempfile) && upload.tempfile.respond_to?(:size)
-        upload.tempfile.size.to_i
-      elsif upload.respond_to?(:to_h)
+      if upload.respond_to?(:to_h)
         io = upload.to_h.symbolize_keys[:io]
-        io.respond_to?(:size) ? io.size.to_i : 0
+        return io.size.to_i if io.respond_to?(:size)
+      end
+
+      if upload.respond_to?(:tempfile) && upload.tempfile.respond_to?(:size)
+        upload.tempfile.size.to_i
+      elsif upload.respond_to?(:size)
+        upload.size.to_i
       else
         0
       end

--- a/app/models/concerns/factory.rb
+++ b/app/models/concerns/factory.rb
@@ -53,7 +53,7 @@ module Factory
     ip_address = params.delete(:ip_address)
     user_agent = params.delete(:user_agent)
 
-    attachments = extract_attachments(params)
+    attachments = normalize_attachments(extract_attachments(params))
     validate_submission_size!(params, attachments)
 
     message = nil
@@ -133,6 +133,10 @@ module Factory
       Array.wrap(raw)
     end
 
+    def normalize_attachments(attachments)
+      attachments.filter_map { |attachment| normalize_attachment(attachment) }
+    end
+
     def validate_submission_size!(params, attachments)
       max_request_body = configured_max_request_body
       return if max_request_body <= 0
@@ -157,8 +161,6 @@ module Factory
         upload.blob.byte_size
       when ActiveStorage::Blob
         upload.byte_size
-      when String
-        find_blob_from_signed_id(upload)&.byte_size.to_i
       else
         attachment_io_byte_size(upload)
       end

--- a/app/models/concerns/factory.rb
+++ b/app/models/concerns/factory.rb
@@ -27,6 +27,7 @@ module Factory
   #   consistent and testable upload lifecycle.
 
   MessageNotOwnedError = Class.new(StandardError)
+  SubmissionSizeExceededError = Class.new(StandardError)
 
   # Create a Message and attach files inside a transaction, then enqueue a
   # broadcast job after the transaction commits.
@@ -53,6 +54,7 @@ module Factory
     user_agent = params.delete(:user_agent)
 
     attachments = extract_attachments(params)
+    validate_submission_size!(params, attachments)
 
     message = nil
     Message.transaction do
@@ -129,6 +131,50 @@ module Factory
       raw = params.delete(:attachments)
       raw = params.delete('attachments') if raw.nil? && params.respond_to?(:key?)
       Array.wrap(raw)
+    end
+
+    def validate_submission_size!(params, attachments)
+      max_request_body = configured_max_request_body
+      return if max_request_body <= 0
+
+      total_size = params[:content].to_s.bytesize + attachments.sum { |attachment| attachment_byte_size(attachment) }
+      return if total_size <= max_request_body
+
+      raise SubmissionSizeExceededError, I18n.t(
+        'messages.form.size_limit_exceeded',
+        max_size: ActiveSupport::NumberHelper.number_to_human_size(max_request_body, precision: 3)
+      )
+    end
+
+    def configured_max_request_body
+      raw_value = Rails.configuration.x.max_request_body
+      raw_value.present? ? raw_value.to_i : 0
+    end
+
+    def attachment_byte_size(upload)
+      case upload
+      when ActiveStorage::Attachment
+        upload.blob.byte_size
+      when ActiveStorage::Blob
+        upload.byte_size
+      when String
+        find_blob_from_signed_id(upload)&.byte_size.to_i
+      else
+        attachment_io_byte_size(upload)
+      end
+    end
+
+    def attachment_io_byte_size(upload)
+      if upload.respond_to?(:size)
+        upload.size.to_i
+      elsif upload.respond_to?(:tempfile) && upload.tempfile.respond_to?(:size)
+        upload.tempfile.size.to_i
+      elsif upload.respond_to?(:to_h)
+        io = upload.to_h.symbolize_keys[:io]
+        io.respond_to?(:size) ? io.size.to_i : 0
+      else
+        0
+      end
     end
 
     # Attach a file with metadata handling (strip, EXIF extraction).

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,19 @@
 class Message < ApplicationRecord
   belongs_to :user
   has_many_attached :attachments, dependent: :purge_later
+
+  validates :content, presence: true
+  validate :content_within_request_body_limit
+
+  private
+
+  def content_within_request_body_limit
+    max_request_body = Rails.configuration.x.max_request_body
+    max_request_body = max_request_body.present? ? max_request_body.to_i : 0
+    return if max_request_body <= 0
+    return if content.blank?
+    return if content.to_s.bytesize <= max_request_body
+
+    errors.add(:content, :too_long, count: max_request_body)
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -14,6 +14,10 @@ class Message < ApplicationRecord
     return if content.blank?
     return if content.to_s.bytesize <= max_request_body
 
-    errors.add(:content, :too_long, count: max_request_body)
+    errors.add(
+      :content,
+      :request_body_too_large,
+      max_size: ActiveSupport::NumberHelper.number_to_human_size(max_request_body, precision: 3)
+    )
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,12 @@ en:
       authorization: "Authorization"
       message: "Message"
       user: "User"
+    errors:
+      models:
+        message:
+          attributes:
+            content:
+              request_body_too_large: "is too large (maximum is %{max_size})"
   errors:
     locale:
       invalid_type: "must be a String or Symbol"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -72,6 +72,12 @@ ja:
       authorization: "認証情報"
       message: "メッセージ"
       user: "ユーザー"
+    errors:
+      models:
+        message:
+          attributes:
+            content:
+              request_body_too_large: "は大きすぎます（最大 %{max_size}）"
   errors:
     locale:
       invalid_type: "は文字列またはシンボルである必要があります"

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -62,5 +62,25 @@ RSpec.describe MessagesController, type: :controller do
       expect(captured[:strip_metadata]).to be false
       expect(captured[:allow_location_public]).to be true
     end
+
+    it 'renders the generic flash message when submission size validation fails' do
+      allow(controller).to receive(:create_message!).and_raise(
+        Factory::SubmissionSizeExceededError,
+        'The data you are trying to submit exceeds the allowed size (1 Byte).'
+      )
+
+      post :create, params: {
+        locale: :en,
+        content: 'with attachment'
+      }, format: :turbo_stream
+
+      expect(flash.now[:alert]).to eq(
+        I18n.t(
+          'messages.errors.generic',
+          error_message: 'The data you are trying to submit exceeds the allowed size (1 Byte).'
+        )
+      )
+      expect(response).to have_http_status(:ok)
+    end
   end
 end

--- a/spec/models/concerns/factory_spec.rb
+++ b/spec/models/concerns/factory_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe Factory, type: :model do
       expect(message.attachments.size).to eq(1)
     end
 
+    it 'rejects submissions that exceed max_request_body before creating records' do
+      allow(Rails.configuration.x).to receive(:max_request_body).and_return(1)
+      file = fixture_file_upload('test_image.jpg', 'image/jpeg')
+      params = {
+        content: 'with attachment',
+        user_id: user.id,
+        attachments: [file]
+      }
+
+      expect {
+        factory.create_message!(params)
+      }.to raise_error(
+        Factory::SubmissionSizeExceededError,
+        I18n.t('messages.form.size_limit_exceeded', max_size: '1 Byte')
+      )
+      expect(Message.exists?(content: 'with attachment')).to be false
+    end
+
     it 'logs a warning when an invalid signed blob id is provided' do
       params = attributes_for(:message).merge(user_id: user.id, attachments: ['invalid-signed-id'])
 

--- a/spec/models/concerns/factory_spec.rb
+++ b/spec/models/concerns/factory_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Factory, type: :model do
     end
 
     it 'rejects submissions that exceed max_request_body before creating records' do
-      allow(Rails.configuration.x).to receive(:max_request_body).and_return(3)
+      allow(Rails.configuration.x).to receive(:max_request_body).and_return(5)
       file = {
-        io: StringIO.new('12'),
+        io: StringIO.new('12345'),
         filename: 'tiny.txt',
         content_type: 'text/plain'
       }
@@ -56,7 +56,7 @@ RSpec.describe Factory, type: :model do
         factory.create_message!(params)
       }.to raise_error(
         Factory::SubmissionSizeExceededError,
-        I18n.t('messages.form.size_limit_exceeded', max_size: '3 Bytes')
+        I18n.t('messages.form.size_limit_exceeded', max_size: '5 Bytes')
       )
       expect(Message.exists?(content: 'a')).to be false
     end

--- a/spec/models/concerns/factory_spec.rb
+++ b/spec/models/concerns/factory_spec.rb
@@ -40,10 +40,14 @@ RSpec.describe Factory, type: :model do
     end
 
     it 'rejects submissions that exceed max_request_body before creating records' do
-      allow(Rails.configuration.x).to receive(:max_request_body).and_return(1)
-      file = fixture_file_upload('test_image.jpg', 'image/jpeg')
+      allow(Rails.configuration.x).to receive(:max_request_body).and_return(3)
+      file = {
+        io: StringIO.new('12'),
+        filename: 'tiny.txt',
+        content_type: 'text/plain'
+      }
       params = {
-        content: 'with attachment',
+        content: 'a',
         user_id: user.id,
         attachments: [file]
       }
@@ -52,9 +56,27 @@ RSpec.describe Factory, type: :model do
         factory.create_message!(params)
       }.to raise_error(
         Factory::SubmissionSizeExceededError,
-        I18n.t('messages.form.size_limit_exceeded', max_size: '1 Byte')
+        I18n.t('messages.form.size_limit_exceeded', max_size: '3 Bytes')
       )
-      expect(Message.exists?(content: 'with attachment')).to be false
+      expect(Message.exists?(content: 'a')).to be false
+    end
+
+    it 'resolves signed blob ids only once per attachment' do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new('signed blob'),
+        filename: 'signed.txt',
+        content_type: 'text/plain'
+      )
+      signed_id = blob.signed_id
+      params = {
+        content: 'with signed id',
+        user_id: user.id,
+        attachments: [signed_id]
+      }
+
+      expect(ActiveStorage::Blob).to receive(:find_signed).once.and_call_original
+
+      factory.create_message!(params)
     end
 
     it 'logs a warning when an invalid signed blob id is provided' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -33,7 +33,12 @@ RSpec.describe Message, type: :model do
         message = build(:message, content: '123456')
 
         expect(message).not_to be_valid
-        expect(message.errors[:content]).to include(I18n.t('errors.messages.too_long', count: 5))
+        expect(message.errors[:content]).to include(
+          I18n.t(
+            'activerecord.errors.models.message.attributes.content.request_body_too_large',
+            max_size: '5 Bytes'
+          )
+        )
       end
     end
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -20,6 +20,23 @@ RSpec.describe Message, type: :model do
       end
     end
 
+    describe "バリデーション" do
+      it "content が必須であること" do
+        message = build(:message, content: nil)
+
+        expect(message).not_to be_valid
+        expect(message.errors[:content]).to include(I18n.t('errors.messages.blank'))
+      end
+
+      it "max_request_body を超える content を無効にすること" do
+        allow(Rails.configuration.x).to receive(:max_request_body).and_return(5)
+        message = build(:message, content: '123456')
+
+        expect(message).not_to be_valid
+        expect(message.errors[:content]).to include(I18n.t('errors.messages.too_long', count: 5))
+      end
+    end
+
     describe "ファイルの添付" do
       it "ファイルを添付できること" do
         message = create(:message)


### PR DESCRIPTION
サーバーへ送信するリクエストのサイズ制限は、前段のプロキシにまかせることにしているのですが、 Rails サーバー側にも仕込んでおくようにします。

設定値は、すでにあるプロキシのための設定値 MAX_REQUEST_BODY を再利用して、その値でもってバリデーションするようにします。

---

## Summary

This PR adds server-side validation for message submissions so message creation no longer relies only on client-side form checks.

## Changes

- require `Message#content` to be present
- validate oversized message content against the configured `MAX_REQUEST_BODY` limit
- add a factory-level submission size check before blobs are created or attached
- reuse the existing `MAX_REQUEST_BODY` setting as the server-side double-check limit
- raise a dedicated submission size error before persistence when the total payload is too large
- verify that the existing `MessagesController` flash/error flow surfaces the validation failure
- add model, concern, and controller specs for the new validation behavior

## Why

The app already had a client-side form size check, but that alone was not sufficient because requests could still bypass the browser-side guard.

This change adds a server-side safety net while keeping the existing deployment model:
- the proxy remains the primary request-size enforcement point
- the application now performs a secondary validation using the same `MAX_REQUEST_BODY` value

## Validation

- `bundle exec rspec`
- `bundle exec rubocop --format simple`