### PR TITLE
添付ファイルの配信を認証付きルートに切り替え

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -28,13 +28,17 @@ class AttachmentsController < ApplicationController
   def representation
     attachment = find_message_attachment
     return head :not_found if attachment.nil?
+    return head :not_found unless attachment.representable?
 
     representation = attachment.representation(variation_transformations).processed
 
     http_cache_forever public: false do
       send_blob_stream representation, disposition: params[:disposition] || 'inline'
     end
-  rescue ActiveStorage::InvariableError, ActiveSupport::MessageVerifier::InvalidSignature
+  rescue ActiveStorage::InvariableError,
+         ActiveStorage::UnrepresentableError,
+         ActiveStorage::UnpreviewableError,
+         ActiveSupport::MessageVerifier::InvalidSignature
     head :not_found
   end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,15 +1,68 @@
 class AttachmentsController < ApplicationController
+  include ActiveStorage::Streaming
+
   before_action :authenticate_user!
 
   def metadata
-    attachment = ActiveStorage::Attachment.find(params[:id])
-    # Note: In a real application with private rooms, you should check
-    # if current_user can view attachment.record (the message).
-    # Since this app is a public board for logged-in users, we just check authentication.
+    attachment = find_message_attachment
+    return render json: {}, status: :not_found if attachment.nil?
 
     options = helpers.image_location_options(attachment)
     render json: options[:data] || {}
-  rescue ActiveRecord::RecordNotFound
-    render json: {}, status: :not_found
   end
+
+  def show
+    attachment = find_message_attachment
+    return head :not_found if attachment.nil?
+
+    stream_blob(attachment.blob, disposition: :inline)
+  end
+
+  def download
+    attachment = find_message_attachment
+    return head :not_found if attachment.nil?
+
+    stream_blob(attachment.blob, disposition: :attachment)
+  end
+
+  def representation
+    attachment = find_message_attachment
+    return head :not_found if attachment.nil?
+
+    representation = attachment.representation(variation_transformations).processed
+
+    http_cache_forever public: false do
+      send_blob_stream representation, disposition: params[:disposition] || 'inline'
+    end
+  rescue ActiveStorage::InvariableError, ActiveSupport::MessageVerifier::InvalidSignature
+    head :not_found
+  end
+
+  private
+
+    def find_message_attachment
+      attachment = ActiveStorage::Attachment.find(params[:id])
+      return attachment if attachment.record.is_a?(Message)
+
+      nil
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
+    def stream_blob(blob, disposition:)
+      if request.headers['Range'].present?
+        send_blob_byte_range_data blob, request.headers['Range']
+      else
+        http_cache_forever public: false do
+          response.headers['Accept-Ranges'] = 'bytes'
+          response.headers['Content-Length'] = blob.byte_size.to_s
+
+          send_blob_stream blob, disposition: disposition
+        end
+      end
+    end
+
+    def variation_transformations
+      ActiveStorage::Variation.decode(params[:variation_key]).transformations
+    end
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -28,15 +28,20 @@
   <div class="container flex" data-message-attachments="true">
     <% if message.attachments.attached? %>
       <% message.attachments.each do |att| %>
+        <% current_locale = params[:locale] || I18n.locale %>
+        <% blob_url = blob_attachment_path(att, locale: current_locale) %>
+        <% download_url = download_attachment_path(att, locale: current_locale) %>
+        <% preview_variation_key = ActiveStorage::Variation.wrap(resize_to_limit: [640, 480]).key %>
+        <% preview_url = representation_attachment_path(att, variation_key: preview_variation_key, locale: current_locale) %>
         <div class="container shrink-0 w-auto mx-2">
           <% if att.representable? %>
             <div class="my-2 h-40 w-40 bg-gray-200 flex cursor-pointer"
-              data-source-url="<%= url_for(att) %>"
+              data-source-url="<%= blob_url %>"
               data-filename="<%= att.filename %>"
               data-content-type="<%= att.content_type %>"
               data-controller="metadata-fetcher"
               data-metadata-fetcher-attachment-id-value="<%= att.id %>"
-              data-metadata-fetcher-metadata-url-value="<%= metadata_attachment_path(att, locale: params[:locale] || I18n.locale) %>"
+              data-metadata-fetcher-metadata-url-value="<%= metadata_attachment_path(att, locale: current_locale) %>"
               data-action="click->metadata-fetcher#prepare click->messages#changePreview"
               <% opts = image_location_options(att) %>
               <% if opts[:data] %>
@@ -46,8 +51,8 @@
             >
               <% if ['video/quicktime', 'video/mp4'].include?(att.content_type) %>
                 <div class="relative">
-                <%= video_tag([rails_blob_path(att)],
-                  poster: url_for(att.representation(resize_to_limit: [640, 480])),
+                <%= video_tag([blob_url],
+                  poster: preview_url,
                   controls: true,
                   muted: true,
                   class: 'lazyload object-contain max-h-full max-w-full my-2',
@@ -65,7 +70,7 @@
                   image_tag('blank.png',
                     class: 'lazyload object-contain max-h-full max-w-full mx-auto my-2',
                     data: {
-                      src: url_for(att),
+                      src: preview_url,
                     }
                   )
                 %>
@@ -73,7 +78,7 @@
             </div>
           <% else %>
             <div class="my-2 h-40 w-40 bg-gray-200 flex cursor-pointer"
-              data-source-url="<%= url_for(att) %>"
+              data-source-url="<%= blob_url %>"
               data-filename="<%= att.filename %>"
               data-content-type="<%= att.content_type %>"
               data-action="click->messages#changePreview"
@@ -91,7 +96,7 @@
 
           <div class="text-xs">
             <%=
-              link_to('&#x1F4BE;'.html_safe, rails_blob_path(att, disposition: 'attachment'),
+              link_to('&#x1F4BE;'.html_safe, download_url,
                 class: 'tooltip-trigger inline-block ',
                 data: {
                   turbo: false,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,10 @@ Rails.application.routes.draw do
     resources :messages, only: [:index, :create, :destroy]
     resources :attachments, only: [] do
       member do
+        get :blob, action: :show
+        get :download
         get :metadata
+        get 'representation/:variation_key', action: :representation, as: :representation
       end
     end
 

--- a/spec/requests/attachments_metadata_spec.rb
+++ b/spec/requests/attachments_metadata_spec.rb
@@ -2,19 +2,16 @@ require 'rails_helper'
 
 RSpec.describe 'Attachments metadata endpoint', type: :request do
   let(:user) { create(:user) }
+  let(:path) { Rails.root.join('spec/fixtures/files/test_image.jpg') }
+  let(:blob) { ActiveStorage::Blob.create_and_upload!(io: File.open(path, 'rb'), filename: 'test_image.jpg', content_type: 'image/jpeg') }
+  let(:message) { Message.create!(content: 'hello', user: user) }
+  let(:attachment) { ActiveStorage::Attachment.create!(name: 'attachments', record: message, blob: blob) }
 
   before do
     sign_in user
   end
 
   it 'returns latitude/longitude when metadata present and public' do
-    path = Rails.root.join('spec/fixtures/files/test_image.jpg')
-    blob = ActiveStorage::Blob.create_and_upload!(io: File.open(path, 'rb'), filename: 'test_image.jpg', content_type: 'image/jpeg')
-
-    # attach to a record (Message) so we have an attachment record
-    message = Message.create!(content: 'hello', user: user)
-    attachment = ActiveStorage::Attachment.create!(name: 'attachments', record: message, blob: blob)
-
     # set metadata as server would
     blob.update!(metadata: {
       'exif' => { 'gps' => { 'latitude' => 35.681236, 'longitude' => 139.767125 } },
@@ -30,11 +27,6 @@ RSpec.describe 'Attachments metadata endpoint', type: :request do
   end
 
   it 'returns empty JSON when metadata present but not public' do
-    path = Rails.root.join('spec/fixtures/files/test_image.jpg')
-    blob = ActiveStorage::Blob.create_and_upload!(io: File.open(path, 'rb'), filename: 'test_image.jpg', content_type: 'image/jpeg')
-    message = Message.create!(content: 'hello', user: user)
-    attachment = ActiveStorage::Attachment.create!(name: 'attachments', record: message, blob: blob)
-
     blob.update!(metadata: {
       'exif' => { 'gps' => { 'latitude' => 35.0, 'longitude' => 139.0 } },
       'upload_settings' => { 'allow_location_public' => false }
@@ -47,6 +39,30 @@ RSpec.describe 'Attachments metadata endpoint', type: :request do
     expect(json).to eq({})
   end
 
+  it 'streams an attachment for authenticated users' do
+    get blob_attachment_path(attachment, locale: 'en')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('image/jpeg')
+    expect(response.headers['Accept-Ranges']).to eq('bytes')
+  end
+
+  it 'downloads an attachment for authenticated users' do
+    get download_attachment_path(attachment, locale: 'en')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.headers['Content-Disposition']).to include('attachment')
+  end
+
+  it 'streams a representation for authenticated users' do
+    variation_key = ActiveStorage::Variation.wrap(resize_to_limit: [640, 480]).key
+
+    get representation_attachment_path(attachment, variation_key: variation_key, locale: 'en')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq('image/jpeg')
+  end
+
   it 'returns 404 and empty body when attachment not found' do
     get '/en/attachments/999999/metadata'
     expect(response).to have_http_status(:not_found)
@@ -54,18 +70,35 @@ RSpec.describe 'Attachments metadata endpoint', type: :request do
     expect(json).to eq({})
   end
 
-  it 'requires authentication (returns 401) when not signed in' do
-    # create an attachment to request
-    path = Rails.root.join('spec/fixtures/files/test_image.jpg')
-    blob = ActiveStorage::Blob.create_and_upload!(io: File.open(path, 'rb'), filename: 'test_image.jpg', content_type: 'image/jpeg')
-    message = Message.create!(content: 'hello', user: user)
-    attachment = ActiveStorage::Attachment.create!(name: 'attachments', record: message, blob: blob)
+  it 'returns 404 when attachment does not belong to a message' do
+    other_attachment = ActiveStorage::Attachment.create!(name: 'avatar', record: user, blob: blob)
 
+    get blob_attachment_path(other_attachment, locale: 'en')
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'requires authentication (returns 401) when not signed in' do
     # sign out the current user to simulate unauthenticated access
     sign_out user
 
     get metadata_attachment_path(attachment, locale: 'en'), headers: { 'ACCEPT' => 'application/json' }
 
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'requires authentication for attachment content routes' do
+    variation_key = ActiveStorage::Variation.wrap(resize_to_limit: [640, 480]).key
+
+    sign_out user
+
+    get blob_attachment_path(attachment, locale: 'en'), headers: { 'ACCEPT' => 'application/octet-stream' }
+    expect(response).to have_http_status(:unauthorized)
+
+    get download_attachment_path(attachment, locale: 'en'), headers: { 'ACCEPT' => 'application/octet-stream' }
+    expect(response).to have_http_status(:unauthorized)
+
+    get representation_attachment_path(attachment, variation_key: variation_key, locale: 'en'), headers: { 'ACCEPT' => 'image/jpeg' }
     expect(response).to have_http_status(:unauthorized)
   end
 end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe "Messages", type: :request do
     end
   end
 
+  describe "GET /messages" do
+    before { sign_in confirmed_user }
+
+    it "renders authenticated attachment routes for attached messages" do
+      file = fixture_file_upload('test_image.jpg', 'image/jpeg')
+      message.attachments.attach(file)
+      variation_key = ActiveStorage::Variation.wrap(resize_to_limit: [640, 480]).key
+
+      get messages_path(locale: :en)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(blob_attachment_path(message.attachments.first, locale: :en))
+      expect(response.body).to include(download_attachment_path(message.attachments.first, locale: :en))
+      expect(response.body).to include(metadata_attachment_path(message.attachments.first, locale: :en))
+      expect(response.body).to include(representation_attachment_path(message.attachments.first, variation_key: variation_key, locale: :en))
+    end
+  end
+
   describe "DELETE /messages/:id" do
     context "when user is confirmed" do
       before { sign_in confirmed_user }


### PR DESCRIPTION
当初は簡便さ優先のため添付ファイルのURLそのままでダウンロードさせていましたが、ユーザー認証を行うルートを設け、ストリーミングでダウンロードするようにします。メタデータのダウンロードがすでに認証ルートになっていたので、揃えるということでもあります。

---

## Summary

This PR moves message attachment delivery behind authenticated application routes.

## Changes

- add authenticated attachment routes for blob delivery, download, metadata, and representations
- extend `AttachmentsController` to stream blobs and previews only after `authenticate_user!`
- return `404` for attachments that do not belong to `Message`
- replace direct Active Storage URLs in the message partial with authenticated app routes
- add request coverage for authenticated delivery, unauthenticated rejection, and rendered attachment URLs in the messages index

## Why

Message attachments were still linked through direct Active Storage URLs even though access should stay inside the app's authenticated boundary.

This change keeps the existing visibility model:
- any signed-in user can still view attachments on the shared board
- unauthenticated users can no longer fetch attachment content or previews through app routes

## Validation

- `bundle exec rspec spec/requests/attachments_metadata_spec.rb spec/requests/messages_spec.rb`
- `bundle exec rspec`
- `bundle exec rubocop --format simple`