### PR TITLE
ログイン画面で不要な Cable 切断通知を出さないようにする

### DIFF
--- a/app/javascript/channels/messages_channel.js
+++ b/app/javascript/channels/messages_channel.js
@@ -1,10 +1,43 @@
 import consumer from "channels/consumer"
 import { appendMessageToStorage, renderFlashMessages, clearFlashMessages } from "flash_unified/all"
 
-consumer.subscriptions.create("MessagesChannel", {
+let subscription = null
+
+function hasMessagesChannelTargets(root = document) {
+  return !!root.querySelector?.('#messages[data-current-user-id], [data-messages-channel="notification"]')
+}
+
+// Only keep a Cable subscription on pages that can actually render message
+// updates or the notification badge. This avoids warning flashes on signed-out pages.
+function createSubscription() {
+  if (subscription) return subscription
+
+  subscription = consumer.subscriptions.create("MessagesChannel", channelDefinition)
+  return subscription
+}
+
+function removeSubscription({ silent = false } = {}) {
+  if (!subscription) return
+
+  subscription.intentionalDisconnect = silent
+  subscription.unsubscribe()
+  subscription = null
+}
+
+function syncSubscriptionForPage() {
+  if (hasMessagesChannelTargets()) {
+    createSubscription()
+    return
+  }
+
+  removeSubscription({ silent: true })
+}
+
+const channelDefinition = {
   connected() {
     // Called when the subscription is ready for use on the server
     console.log("MessagesChannel: connected")
+    this.intentionalDisconnect = false
     this.boundDocumentClick = this.handleDocumentClick.bind(this)
     this.boundSyncMessagesUi = this.syncMessagesUi.bind(this)
 
@@ -22,6 +55,8 @@ consumer.subscriptions.create("MessagesChannel", {
     document.removeEventListener('click', this.boundDocumentClick)
     document.removeEventListener('turbo:load', this.boundSyncMessagesUi)
     document.removeEventListener('turbo:render', this.boundSyncMessagesUi)
+
+    if (this.intentionalDisconnect || !hasMessagesChannelTargets()) return
 
     const flashMessage = this.disconnectedMessage();
     clearFlashMessages(flashMessage);
@@ -252,4 +287,16 @@ consumer.subscriptions.create("MessagesChannel", {
     const fallbackMessage = "Connection to the server has been lost. Please reload the page to reconnect";
     return this.localeMessage('cable_disconnected') || fallbackMessage;
   }
-});
+};
+
+document.addEventListener('turbo:before-render', (event) => {
+  // Tear down quietly before navigating to a page that has no message-related UI.
+  if (hasMessagesChannelTargets(event.detail.newBody)) return
+
+  removeSubscription({ silent: true })
+})
+
+document.addEventListener('turbo:load', syncSubscriptionForPage)
+document.addEventListener('turbo:render', syncSubscriptionForPage)
+
+syncSubscriptionForPage()

--- a/spec/system/hello_spec.rb
+++ b/spec/system/hello_spec.rb
@@ -8,5 +8,15 @@ RSpec.describe "Main Page", type: :system do
       visit root_path
       expect(page).to have_selector('h2', text: 'Log in')
     end
+
+    it 'does not show cable disconnected warning on login page reload' do
+      # The login page intentionally has no Action Cable UI, so reloading it
+      # should not surface a disconnect warning.
+      visit new_user_session_path(locale: :ja)
+      visit current_path
+
+      expect(page).to have_selector('h2', text: 'ログイン')
+      expect(page).to have_no_selector('[data-testid="flash-message"]', text: I18n.t('exports.cable_disconnected'), wait: 1)
+    end
   end
 end


### PR DESCRIPTION
ログイン画面で、 "サーバーとの接続が切れました。再接続するには画面をリロードしてください。"  が必ず出てしまう症状がありましたので、修正します。ログイン画面はすなわちログインしていない状態なので、それを判断してメッセージを抑制します。

---

## Summary

This PR refines the Action Cable wiring so signed-out pages do not create or keep a `MessagesChannel` subscription.

## Changes

- create the `MessagesChannel` subscription only on pages that actually need message updates or the notification badge
- silently tear down the subscription when navigating to pages without message-related UI
- prevent the login page from showing a cable disconnected warning on reload
- add a system regression spec for the login page reload behavior
- add concise code comments describing the intent of the wiring change

## Why

The sign-in page does not have any Action Cable-driven UI, but the global channel wiring still created a subscription there. When the server rejected or closed that connection, the client showed the generic cable disconnected flash message, which produced a poor experience on every reload.

This change keeps the existing realtime behavior on the messages page while avoiding unnecessary websocket lifecycle noise on signed-out pages.

## Validation

- `bundle exec rspec spec/system/hello_spec.rb spec/system/messages_spec.rb`