### PR TITLE
Update GitHub Actions to use specific versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       RAILS_ENV: test
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Generate Active Record encryption keys
         run: |
@@ -25,7 +25,7 @@ jobs:
       - name: Read Ruby version
         run: echo "RUBY_VERSION=$(cat .ruby-version)" >> $GITHUB_ENV
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
@@ -69,7 +69,7 @@ jobs:
         timeout-minutes: 3
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: coverage-report
@@ -86,7 +86,7 @@ jobs:
 
       - name: Coveralls GitHub Action
         if: steps.coveralls_check.outputs.available == 'true'
-        uses: coverallsapp/github-action@v2.3.6
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage/lcov.info

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Read Ruby version
         run: echo "RUBY_VERSION=$(cat .ruby-version)" >> $GITHUB_ENV
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use specific commit SHAs for third-party actions instead of version tags. This change improves security and reliability by ensuring that the workflows always use the exact intended version of each action, protecting against unexpected changes in upstream dependencies.

**Workflow dependency pinning:**

* Updated `actions/checkout` to use commit SHA `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` in both `.github/workflows/ci.yml` and `.github/workflows/rubocop.yml`, replacing the previous version tags. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R17) [[2]](diffhunk://#diff-b79dca49270186d1f5b31d431888b2811a16786f6d590f1a5220507d3de190cbL16-R22)
* Updated `ruby/setup-ruby` to use commit SHA `89f90524b88a01fe6e0b732220432cc6142926af` in both workflow files, replacing the previous version tags. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL28-R28) [[2]](diffhunk://#diff-b79dca49270186d1f5b31d431888b2811a16786f6d590f1a5220507d3de190cbL16-R22)
* Updated `actions/upload-artifact` to use commit SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` in `.github/workflows/ci.yml`.
* Updated `coverallsapp/github-action` to use commit SHA `648a8eb78e6d50909eff900e4ec85cab4524a45b` in `.github/workflows/ci.yml`.