### PR TITLE
Update solid_cable dependency to version 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ group :test do
   gem 'simplecov-lcov', require: false
 end
 
-gem 'solid_cable', '~> 3.0'
+gem 'solid_cable', '>= 4.0'
 gem 'solid_cache', '~> 1.0'
 
 gem 'tailwindcss-rails', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,7 +474,7 @@ GEM
     snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
-    solid_cable (3.0.12)
+    solid_cable (4.0.0)
       actioncable (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -589,7 +589,7 @@ DEPENDENCIES
   shoulda-matchers (~> 7.0)
   simplecov
   simplecov-lcov
-  solid_cable (~> 3.0)
+  solid_cable (>= 4.0)
   solid_cache (~> 1.0)
   sqlite3 (>= 2.1)
   stimulus-rails
@@ -771,7 +771,7 @@ CHECKSUMS
   simplecov-lcov (0.9.0) sha256=7a77a31e200a595ed4b0249493056efd0c920601f53d2ef135ca34ee796346cd
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a
-  solid_cable (3.0.12) sha256=a168a54731a455d5627af48d8441ea3b554b8c1f6e6cd6074109de493e6b0460
+  solid_cable (4.0.0) sha256=8379680ef6bf36e195eb876a6306ea290f87d5fa10bc4a757bc2a918f83229b5
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b


### PR DESCRIPTION
This pull request updates the `solid_cable` gem version constraint in the `Gemfile` to allow for versions 4.0 and above, ensuring compatibility with the latest releases. No other changes are included.

- Dependency update:
  * Updated the `solid_cable` gem version requirement from `~> 3.0` to `>= 4.0` in the `Gemfile` to support newer versions.