### PR TITLE
Upgrade image_processing to version 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,9 @@ gem 'tzinfo-data', platforms: %i[ windows jruby ]
 gem 'bootsnap', require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem 'image_processing', '~> 1.2'
+gem 'image_processing', '>= 2.0.2'
+gem 'mini_magick', '>= 5.3.1'
+gem 'ruby-vips', '>= 2.3'
 gem 'exifr'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,9 +190,7 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
-      ruby-vips (>= 2.0.17, < 3)
+    image_processing (2.0.2)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -565,11 +563,12 @@ DEPENDENCIES
   factory_bot_rails
   flash_unified
   http_accept_language
-  image_processing (~> 1.2)
+  image_processing (>= 2.0.2)
   importmap-rails
   jbuilder
   kamal
   kaminari (~> 1.2)
+  mini_magick (>= 5.3.1)
   omniauth
   omniauth-github
   omniauth-rails_csrf_protection
@@ -585,6 +584,7 @@ DEPENDENCIES
   rqrcode
   rspec-rails (~> 8.0)
   rubocop-rails-omakase
+  ruby-vips (>= 2.3)
   selenium-webdriver
   shoulda-matchers (~> 7.0)
   simplecov
@@ -667,7 +667,7 @@ CHECKSUMS
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   http_accept_language (2.1.1) sha256=0043f0d55a148cf45b604dbdd197cb36437133e990016c68c892d49dbea31634
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
+  image_processing (2.0.2) sha256=d0cf990f862d64efb1a14916044bf4b5bb2bccc7e235022413cde46019799cfa
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3


### PR DESCRIPTION
This pull request updates the image processing dependencies in the `Gemfile` to support newer versions and additional backends. The main changes are:

**Dependency updates and enhancements:**

* Updated `image_processing` gem to require version `>= 2.0.2` instead of `~> 1.2`, allowing for newer versions and features.
* Added `mini_magick` gem with version `>= 5.3.1` to explicitly support MiniMagick as an image processing backend.
* Added `ruby-vips` gem with version `>= 2.3` to provide support for the libvips image processing backend.