### PR TITLE
Add libvips to CI workflow installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install tools (ImageMagick, SQLite3, etc.)
         run: |
           sudo apt-get update
-          sudo apt-get install -y imagemagick sqlite3 libsqlite3-dev
+          sudo apt-get install -y imagemagick sqlite3 libsqlite3-dev libvips
 
       - name: Install Google Chrome
         run: |


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by adding an additional system dependency to the installation step.

- Added `libvips` to the list of packages installed during the CI setup in `.github/workflows/ci.yml` to support image processing or related tasks.