### PR TITLE
Local CI setup

### DIFF
--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,22 +1,26 @@
 # Run using bin/ci
 
 CI.run do
-  step "Setup", "bin/setup --skip-server"
+  step "Setup: Local test prerequisites", <<~SH
+    bundle check || bundle install
+    env RAILS_ENV=test bin/rails db:prepare
+  SH
 
-  step "Style: Ruby", "bin/rubocop"
-
+  step "Style: RuboCop", "bin/rubocop"
+  step "Security: Brakeman", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
   step "Security: Importmap vulnerability audit", "bin/importmap audit"
-  step "Tests: Rails", "bin/rails test"
-  step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+  step "Tests: RSpec(1/2)", "bin/rspec"
+  step "Tests: RSpec(2/2)", "env RSPEC_DISABLE_OAUTH_GITHUB=1 bin/rspec spec/system/oauth_github_disabled/"
 
-  # Optional: Run system tests
-  # step "Tests: System", "bin/rails test:system"
-
-  # Optional: set a green GitHub commit status to unblock PR merge.
-  # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.
-  # if success?
-  #   step "Signoff: All systems go. Ready for merge and deploy.", "gh signoff"
-  # else
-  #   failure "Signoff: CI failed. Do not merge or deploy.", "Fix the issues and try again."
-  # end
+  step "Docker: Build and boot staging image", <<~SH
+    docker build --build-arg RAILS_ENV=staging -t annabelle-staging-check .
+    docker run --rm \
+      -e RAILS_ENV=staging \
+      -e SECRET_KEY_BASE_DUMMY=1 \
+      -e DOCKER=1 \
+      -e ANNABELLE_VARIANT_PROCESSOR=vips \
+      --entrypoint bin/rails \
+      annabelle-staging-check \
+      runner 'Rails.application.eager_load!; puts :ok'
+  SH
 end


### PR DESCRIPTION
Rails 8.1 から導入されたローカル CI を使ってみます。
差し当たっては動作することを優先して詳細点は追って詰めていければと思います。

---


This pull request updates the continuous integration (CI) pipeline configuration in `config/ci.rb` to improve test setup, expand security checks, and enhance the testing process. The main changes include refining environment setup, adding new security steps, switching from Rails tests to RSpec, and introducing a Docker build and boot check.

**CI Pipeline Improvements:**

* Refined the local test prerequisites step to explicitly check for and install missing gems, and to prepare the test database with `RAILS_ENV=test bin/rails db:prepare`.
* Split RSpec tests into two steps: a general run and a separate run for system tests with GitHub OAuth disabled (`RSPEC_DISABLE_OAUTH_GITHUB=1`).

**Security Enhancements:**

* Added a new Brakeman security scan step (`bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error`).
* Kept the Importmap vulnerability audit step for front-end dependency security.

**Docker Integration:**

* Added a step to build and boot a Docker staging image, ensuring the application can start in a containerized staging environment.

**Other Changes:**

* Updated step naming conventions for clarity (e.g., "Style: RuboCop" instead of "Style: Ruby"). (Fb