### PR TITLE
Remove RuboCop job and redundant dependency installation from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,36 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  rubocop:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    env:
-      IMAGE_NAME: annabelle-rubocop:latest
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Build runtime-dev image
-        run: |
-          docker build \
-            --target runtime-dev \
-            --build-arg RAILS_ENV=development \
-            --build-arg BUNDLE_WITHOUT= \
-            --build-arg PRECOMPILE_ASSETS=0 \
-            --tag "$IMAGE_NAME" \
-            .
-
-      - name: Run RuboCop inside container
-        run: |
-          docker run --rm "$IMAGE_NAME" bash -lc '
-            if [ -x bin/rubocop ]; then
-              bin/rubocop
-            else
-              bundle exec rubocop
-            fi
-          '
-
   rspec:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -24,11 +24,6 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
 
-      - name: Install dependencies
-        run: |
-          # Ensure gems are installed (setup-ruby may have already done this, but run explicitly for safety)
-          bundle install --jobs 4 --retry 3
-
       - name: Run RuboCop
         run: |
           # Prefer the binstub if present, otherwise use bundle exec


### PR DESCRIPTION
ワークフローにおける RuboCop の設定が冗長だったので、その部分を取り除きます。

