### PR TITLE
db:migrate 実行によるスキーマダンプの追従（active_storage_attachments の外部キー反映）

### DIFF
--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,10 +1,22 @@
-ActiveRecord::Schema[7.2].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 1) do
   create_table "solid_cache_entries", force: :cascade do |t|
-    t.binary "key", limit: 1024, null: false
-    t.binary "value", limit: 536870912, null: false
-    t.datetime "created_at", null: false
-    t.integer "key_hash", limit: 8, null: false
     t.integer "byte_size", limit: 4, null: false
+    t.datetime "created_at", null: false
+    t.binary "key", limit: 1024, null: false
+    t.integer "key_hash", limit: 8, null: false
+    t.binary "value", limit: 536870912, null: false
     t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
     t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
     t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -108,6 +108,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_27_151921) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authorizations", "users"
   add_foreign_key "image_metadata_actions", "users"


### PR DESCRIPTION
（この差分についての調査・解説は Claude Sonnet 5.5 によるもので、この PR の文章も作ってもらいました）

## 概要

`rails db:migrate` を実行したところ、マイグレーション自体は何も適用されず（pending migration なし）、
`db/schema.rb` と `db/cache_schema.rb` のみに差分が発生した。DBスキーマ自体への変更は含まれていない。

## 差分の内容

### db/schema.rb
```diff
+ add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
```

### db/cache_schema.rb
- `ActiveRecord::Schema[7.2]` → `ActiveRecord::Schema[8.1]` のバージョン表記更新
- 生成ヘッダコメントの追加
- カラム定義の順序変更（意味的な差分なし）

## 原因調査

- `db/migrate/20240626104509_create_active_storage_tables.active_storage.rb` を確認した結果、
  `active_storage_attachments` テーブルへの外部キー（`t.foreign_key :active_storage_blobs, column: :blob_id`）は
  このマイグレーションの `create_table` ブロック内に元々含まれており、初回実行時点から DB 上には既に存在していた。
- 今回の変更は、DBスキーマの実体を変更したものではなく、`rails` gem を Rails 8.1 系にアップデートしたことに伴い、
  スキーマダンパー（`db:schema:dump`）の出力内容が変わり、以前は `schema.rb` に反映されていなかった
  既存の外部キーが正しく出力されるようになったものと考えられる。
- 参考: PostgreSQL 環境における schema dumper の外部キー出力周りの不具合修正が Rails 本体でも
  議論されている（rails/rails#56560, rails/rails#56072）。ただし今回の事象を厳密に一致させて
  説明する一次情報までは特定できていない。

## 影響範囲

- DB の実データ・制約に変更はない。
- 既に `db:migrate` で構築済みの環境（本番・既存の開発環境等）には影響なし。
  マイグレーション自体は以前から実行済みであり、対象の外部キーは既にDB上に存在しているため。

### ⚠️ 影響が出る可能性があるケース

**本PR適用前の `schema.rb` を使って `db:schema:load` で新規にDBを構築した環境**では、
この外部キー制約が作られないまま構築されてしまう可能性がある。

`db:schema:load` はマイグレーションファイルを実行せず、`schema.rb` の記述内容のみを元にDBを再構築するため、
修正前の `schema.rb` に外部キーが記載されていなければ、そのまま欠落した状態のDBができあがる。

対象となりうる環境の例：
- CI環境のテストDB
- 新規参画者のローカル開発環境
- 本PRのマージ前に `schema:load` で構築されたステージング環境 等

このFK制約が欠けた状態でも、Active Storage の通常のCRUD操作自体が即座に失敗することはないが、
DBレベルでの参照整合性チェックが効かなくなる（サイレントな不整合）。

### ⚠️ 影響が出る可能性があるケース

**本PR適用前の `schema.rb` を使って `db:schema:load` または `db:prepare` で新規にDBを構築した環境**では、
この外部キー制約が作られないまま構築されてしまう可能性がある。

`db:schema:load` はマイグレーションファイルを実行せず、`schema.rb` の記述内容のみを元にDBを再構築する。
`db:prepare` も、DBが未作成、またはテーブルが存在しない状態（＝新規構築時）では内部的に同じ
スキーマロードの経路をたどるため、同様の影響を受ける
（DBおよびテーブルが既に存在する状態で `db:prepare` を実行した場合は、代わりに保留中のマイグレーションが
実行されるため影響を受けない）。

本プロジェクトでは初期構築手順として `db:prepare` を案内しているため、
本PRマージ前に `db:prepare` で構築された環境は影響を受けている可能性がある。

対象となりうる環境の例：
- `db:prepare` で構築されたローカル開発環境（新規参画者含む）
- CI環境のテストDB（`db:schema:load` を使用している場合）
- 本PRのマージ前に `db:prepare` / `db:schema:load` で構築されたステージング環境 等

このFK制約が欠けた状態でも、Active Storage の通常のCRUD操作自体が即座に失敗することはないが、
DBレベルでの参照整合性チェックが効かなくなる（サイレントな不整合）。

### 対処法

上記に該当する環境が既に存在する場合は、以下のいずれかで対処すること。

1. **推奨**: DBを作り直す
```bash
   bin/rails db:drop db:create db:migrate
```
   （`db:prepare` ではなく `db:migrate` を明示的に使うことで、全マイグレーションが実際に実行され、
   `active_storage_attachments` の外部キーを含む正しい状態でDBが再構築される）

2. 上記が難しい場合は、対象環境で直接FKを追加する
```bash
   bin/rails runner "ActiveRecord::Base.connection.add_foreign_key(:active_storage_attachments, :active_storage_blobs, column: :blob_id) unless ActiveRecord::Base.connection.foreign_key_exists?(:active_storage_attachments, column: :blob_id)"
```

本PRマージ後に新規構築する環境については `schema.rb` に修正が反映されているため、
`db:prepare` でも `db:migrate` でも同一の結果が得られる。
