### PR TITLE
ci: coverage ディレクトリが作成できずにCIがFAILする問題の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && ln -sf /usr/bin/chromium /usr/bin/google-chrome \
   && ln -sf /usr/bin/chromium /usr/bin/chromium-browser \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && install -d -o rails -g rails /rails/coverage
 
 USER rails:rails
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,13 @@ if ENV['RSPEC_DISABLE_OAUTH_GITHUB']
 else
   SimpleCov.command_name 'rspec_oauth_github_enabled'
 end
+# NOTE:
+# This SimpleCov output directory is coupled with Docker/CI settings.
+# If you change c.output_directory, update all related paths together:
+# - runtime-test image setup that prepares the coverage directory
+# - coverage artifact collection path (if applicable)
+# Any mismatch can cause CI failures such as permission denied
+# or missing coverage artifacts.
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.output_directory = 'coverage'
   c.lcov_file_name = 'lcov.info'


### PR DESCRIPTION
#255 の差分で COPY の仕方を変えたことによる影響で、 coverage ディレクトリが存在しない状況になり、 CI の最後のステップで coverage ファイルを生成できずに落ちてしまう問題の対処です。 (permission denied)

いったん Quick fix としてこの差分で対処します。

別のタスクを作り、ローカルCIを見直すことにより、push 前に確認（検知）ができるように対応しようと思います。
