### PR TITLE
ローカル CI の見直し（コンテナ内で rspec を実行するようにする）

### DIFF
--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,30 +1,74 @@
 # Run using bin/ci
 
 CI.run do
-  step "Setup: Local test prerequisites", <<~SH
+  step "Setup: Local prerequisites", <<~SH
+    set -eu
     bundle check || bundle install
-    env RAILS_ENV=test bin/rails db:prepare
   SH
 
   step "Style: RuboCop", "bin/rubocop"
   step "Security: Brakeman", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
   step "Security: Importmap vulnerability audit", "bin/importmap audit"
-  step "Tests: RSpec(1/2)", "bin/rspec"
-  step "Tests: RSpec(2/2)", "env RSPEC_DISABLE_OAUTH_GITHUB=1 bin/rspec spec/system/oauth_github_disabled/"
+
+  step "Docker: Build and test runtime-test image", <<~SH
+    set -eu
+
+    IMAGE_NAME=annabelle-runtime-test-check:latest
+    CONTAINER_NAME=annabelle-runtime-test-check
+
+    export ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="$(openssl rand -hex 32)"
+    export ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="$(openssl rand -hex 32)"
+    export ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="$(openssl rand -hex 32)"
+
+    docker build \
+      --target runtime-test \
+      --build-arg RAILS_ENV=test \
+      --build-arg BUNDLE_WITHOUT=development \
+      --build-arg PRECOMPILE_ASSETS=1 \
+      --tag "$IMAGE_NAME" \
+      .
+
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    trap 'docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true' EXIT
+
+    docker run --name "$CONTAINER_NAME" \
+      -e DOCKER=1 \
+      -e RAILS_ENV=test \
+      -e ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT \
+      "$IMAGE_NAME" \
+      bash -lc '
+        set -eu
+        bin/rails db:prepare
+        bundle exec rspec
+        RSPEC_DISABLE_OAUTH_GITHUB=1 bin/rspec spec/system/oauth_github_disabled/
+        test -f /rails/coverage/lcov.info
+      '
+  SH
 
   step "Docker: Build and boot staging image", <<~SH
+    set -eu
+
+    IMAGE_NAME=annabelle-staging-check:latest
+
     docker build --target runtime \
       --build-arg RAILS_ENV=staging \
       --build-arg BUNDLE_WITHOUT=development:test \
       --build-arg PRECOMPILE_ASSETS=1 \
-      -t annabelle-staging-check .
+      --tag "$IMAGE_NAME" \
+      .
+
     docker run --rm \
       -e RAILS_ENV=staging \
       -e SECRET_KEY_BASE_DUMMY=1 \
       -e DOCKER=1 \
       -e ANNABELLE_VARIANT_PROCESSOR=vips \
+      -e ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT \
       --entrypoint bin/rails \
-      annabelle-staging-check \
-      runner 'Rails.application.eager_load!; puts :ok'
+      "$IMAGE_NAME" \
+      runner "Rails.application.eager_load!; puts :ok"
   SH
 end


### PR DESCRIPTION
#256 の対応に関連して、ローカル CI の内容を見直します。 runtime-test コンテナ内で rspec を実行するようにし、 GitHub 上の CI の動作に合わせます。（ローカル CI はもともと、 GitHub 上の CI を走らせる前に手元でチェックするためのもの、という位置付けです。）

また環境変数の設定についても見直しています。

---

This pull request updates the CI pipeline configuration to improve testing reliability and Docker integration. The main changes include adding a new Docker-based test step, enhancing environment variable handling for encryption keys, and making the Docker build and run steps more robust.

**CI Pipeline Improvements:**

* Added a new step to build and test the `runtime-test` Docker image, running database setup and RSpec tests inside a container with generated encryption keys, and verifying coverage output.
* Improved the "Build and boot staging image" step by switching to parameterized image names, adding encryption key environment variables, and ensuring consistent Docker build arguments.

**General Enhancements:**

* Updated the setup step description and removed redundant database preparation from the host environment, as this is now handled inside the Docker container.
* Ensured all shell scripts use `set -eu` for safer execution and better error handling.