### PR TITLE
Release v1.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,12 +111,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /rails /rails
-COPY --from=build /usr/local/bundle /usr/local/bundle
-
 RUN useradd rails --create-home --shell /bin/bash \
-  && mkdir -p /rails/db /rails/log /rails/storage /rails/tmp /usr/local/bundle \
-  && chown -R rails:rails /rails /usr/local/bundle
+  && mkdir -p /rails/db /rails/log /rails/storage /rails/tmp /usr/local/bundle
+
+COPY --from=build --chown=rails:rails /rails /rails
+COPY --from=build --chown=rails:rails /usr/local/bundle /usr/local/bundle
 
 FROM runtime-base AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && ln -sf /usr/bin/chromium /usr/bin/google-chrome \
   && ln -sf /usr/bin/chromium /usr/bin/chromium-browser \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && install -d -o rails -g rails /rails/coverage
 
 USER rails:rails
 

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,30 +1,74 @@
 # Run using bin/ci
 
 CI.run do
-  step "Setup: Local test prerequisites", <<~SH
+  step "Setup: Local prerequisites", <<~SH
+    set -eu
     bundle check || bundle install
-    env RAILS_ENV=test bin/rails db:prepare
   SH
 
   step "Style: RuboCop", "bin/rubocop"
   step "Security: Brakeman", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
   step "Security: Importmap vulnerability audit", "bin/importmap audit"
-  step "Tests: RSpec(1/2)", "bin/rspec"
-  step "Tests: RSpec(2/2)", "env RSPEC_DISABLE_OAUTH_GITHUB=1 bin/rspec spec/system/oauth_github_disabled/"
+
+  step "Docker: Build and test runtime-test image", <<~SH
+    set -eu
+
+    IMAGE_NAME=annabelle-runtime-test-check:latest
+    CONTAINER_NAME=annabelle-runtime-test-check
+
+    export ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="$(openssl rand -hex 32)"
+    export ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="$(openssl rand -hex 32)"
+    export ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="$(openssl rand -hex 32)"
+
+    docker build \
+      --target runtime-test \
+      --build-arg RAILS_ENV=test \
+      --build-arg BUNDLE_WITHOUT=development \
+      --build-arg PRECOMPILE_ASSETS=1 \
+      --tag "$IMAGE_NAME" \
+      .
+
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    trap 'docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true' EXIT
+
+    docker run --name "$CONTAINER_NAME" \
+      -e DOCKER=1 \
+      -e RAILS_ENV=test \
+      -e ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT \
+      "$IMAGE_NAME" \
+      bash -lc '
+        set -eu
+        bin/rails db:prepare
+        bundle exec rspec
+        RSPEC_DISABLE_OAUTH_GITHUB=1 bin/rspec spec/system/oauth_github_disabled/
+        test -f /rails/coverage/lcov.info
+      '
+  SH
 
   step "Docker: Build and boot staging image", <<~SH
+    set -eu
+
+    IMAGE_NAME=annabelle-staging-check:latest
+
     docker build --target runtime \
       --build-arg RAILS_ENV=staging \
       --build-arg BUNDLE_WITHOUT=development:test \
       --build-arg PRECOMPILE_ASSETS=1 \
-      -t annabelle-staging-check .
+      --tag "$IMAGE_NAME" \
+      .
+
     docker run --rm \
       -e RAILS_ENV=staging \
       -e SECRET_KEY_BASE_DUMMY=1 \
       -e DOCKER=1 \
       -e ANNABELLE_VARIANT_PROCESSOR=vips \
+      -e ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY \
+      -e ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT \
       --entrypoint bin/rails \
-      annabelle-staging-check \
-      runner 'Rails.application.eager_load!; puts :ok'
+      "$IMAGE_NAME" \
+      runner "Rails.application.eager_load!; puts :ok"
   SH
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,13 @@ if ENV['RSPEC_DISABLE_OAUTH_GITHUB']
 else
   SimpleCov.command_name 'rspec_oauth_github_enabled'
 end
+# NOTE:
+# This SimpleCov output directory is coupled with Docker/CI settings.
+# If you change c.output_directory, update all related paths together:
+# - runtime-test image setup that prepares the coverage directory
+# - coverage artifact collection path (if applicable)
+# Any mismatch can cause CI failures such as permission denied
+# or missing coverage artifacts.
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.output_directory = 'coverage'
   c.lcov_file_name = 'lcov.info'


### PR DESCRIPTION
アプリケーションの変更はありません。
Docker イメージがやたら大きい状況を改善するので、リリースします。その他ローカル CI の見直しをしています。

---

This pull request improves the CI pipeline and Docker image setup to ensure better test isolation, coverage artifact handling, and permissions management for Rails applications. The main changes include running tests inside a dedicated Docker container, updating file ownership for mounted volumes, and clarifying coverage directory configuration.

**CI Pipeline and Docker Integration:**

* The CI script (`config/ci.rb`) now builds and runs tests inside a `runtime-test` Docker container, ensuring that the test environment matches production as closely as possible. It also verifies that the coverage report (`/rails/coverage/lcov.info`) is generated and accessible.
* The Dockerfile now copies application files and Ruby gems with the correct ownership (`rails:rails`), preventing permission issues when writing coverage or log files during tests.
* The Dockerfile explicitly creates the `/rails/coverage` directory with the correct owner, ensuring that coverage artifacts can be written without errors.

**Test Coverage Handling:**

* A prominent comment was added to `spec/rails_helper.rb` warning that the SimpleCov output directory must stay in sync with Docker/CI settings, to avoid issues with missing or inaccessible coverage artifacts.

**Other Improvements:**

* Minor CI step descriptions were clarified for better readability and maintainability.